### PR TITLE
feat(logger): make error message capture opt-in

### DIFF
--- a/docs/middleware/structured-logging.md
+++ b/docs/middleware/structured-logging.md
@@ -31,11 +31,13 @@ provider registry when every resolved model should use the same policy.
 
 Default records include call identity, provider/model identity, duration,
 outcome, request summaries, usage, finish reason, warnings, response metadata,
-and stream timing/counts. Prompt text, output text, reasoning, tool payloads,
-files, headers, bodies, provider options, and raw chunks are not captured by
-default.
+and stream timing/counts. Error records retain structured classification, Go
+type, HTTP status, and retryability when available. Prompt text, output text,
+reasoning, tool payloads, files, headers, bodies, provider options, raw chunks,
+and opaque error messages are not captured by default.
 
-This default is appropriate for most production environments. Add payload
+This default is appropriate for most production environments. A host can make
+its metadata-only policy explicit with `ErrorMessages: false`. Add payload
 capture only for a defined debugging or audit requirement:
 
 ```go
@@ -52,6 +54,30 @@ model := logger.Wrap(baseModel, logger.Options{
 
 Keep capture bounded, sampled, and short-lived. Confirm that retention,
 regional, tenant, and user-consent requirements allow the selected content.
+
+## Choose whether to capture error messages
+
+Error class/type, HTTP status, retryability, operation, outcome, timing, and
+model identity are structured metadata and remain available when opaque error
+messages are disabled. This policy applies to generate errors, stream-open
+errors, streamed error parts, cancellation, and timeouts.
+
+Set `ErrorMessages` only when the provider, transport, middleware, and hook
+error text is safe for your logging environment:
+
+```go
+model := logger.Wrap(baseModel, logger.Options{
+	Logger: log,
+	Capture: logger.CaptureOptions{
+		ErrorMessages: true,
+	},
+})
+```
+
+Captured messages are bounded by `MaxStringLen` and pass through the configured
+redactor. They remain opaque strings, however, so the default redactor cannot
+reliably remove request details, response details, URLs, or other sensitive
+values embedded in them.
 
 ## Add request correlation
 

--- a/middleware/logger/doc.go
+++ b/middleware/logger/doc.go
@@ -22,7 +22,8 @@
 // response metadata, and stream part counts. Streams also report time to first
 // content when content is observed. Prompt text, generated text, reasoning,
 // tool payloads, files, raw chunks, headers, request/response bodies, provider
-// options, and provider metadata require explicit CaptureOptions.
+// options, provider metadata, and opaque error messages require explicit
+// CaptureOptions.
 //
 // Terminal records prefer response provider/model metadata when a gateway or
 // router reports the backend that served the call. The original wrapper identity

--- a/middleware/logger/logger.go
+++ b/middleware/logger/logger.go
@@ -88,8 +88,8 @@ func (l *modelLogger) dynamicAttrs(ctx context.Context) (attrs []slog.Attr) {
 		return nil
 	}
 	defer func() {
-		if recovered := recover(); recovered != nil {
-			attrs = []slog.Attr{slog.String("ai_sdk.serialization_error", fmt.Sprintf("dynamic attrs panic: %v", recovered))}
+		if recover() != nil {
+			attrs = []slog.Attr{slog.String("ai_sdk.serialization_error", "dynamic attrs panic")}
 		}
 	}()
 	return l.opts.dynamicAttrs(ctx)
@@ -97,9 +97,9 @@ func (l *modelLogger) dynamicAttrs(ctx context.Context) (attrs []slog.Attr) {
 
 func (l *modelLogger) redactAttrs(ctx context.Context, event EventKind, attrs []slog.Attr) (out []slog.Attr) {
 	defer func() {
-		if recovered := recover(); recovered != nil {
+		if recover() != nil {
 			out = DefaultRedactor().RedactAttrs(ctx, event, attrs)
-			out = append(out, slog.String("ai_sdk.serialization_error", fmt.Sprintf("redactor panic: %v", recovered)))
+			out = append(out, slog.String("ai_sdk.serialization_error", "redactor panic"))
 		}
 	}()
 	return l.opts.redactor.RedactAttrs(ctx, event, attrs)
@@ -107,29 +107,26 @@ func (l *modelLogger) redactAttrs(ctx context.Context, event EventKind, attrs []
 
 func (l *modelLogger) logAttrs(ctx context.Context, level slog.Level, message string, attrs ...slog.Attr) {
 	defer func() {
-		if recovered := recover(); recovered != nil {
-			logHandlerPanic(ctx, l.opts.logger, recovered)
+		if recover() != nil {
+			logHandlerPanic(ctx)
 		}
 	}()
 	l.opts.logger.LogAttrs(ctx, level, message, attrs...)
 }
 
-func logHandlerPanic(ctx context.Context, logger *slog.Logger, recovered any) {
-	defaultLogger := slog.Default()
-	if logger.Handler() != defaultLogger.Handler() {
-		logged := false
-		func() {
-			defer func() { _ = recover() }()
-			defaultLogger.LogAttrs(ctx, slog.LevelError, "logger: slog handler panic",
-				slog.Any("panic", recovered),
-			)
-			logged = true
-		}()
-		if logged {
-			return
-		}
+func logHandlerPanic(ctx context.Context) {
+	logged := false
+	func() {
+		defer func() { _ = recover() }()
+		slog.Default().LogAttrs(ctx, slog.LevelError, "logger: slog handler panic",
+			slog.String("ai_sdk.serialization_error", "slog handler panic"),
+		)
+		logged = true
+	}()
+	if logged {
+		return
 	}
-	_, _ = fmt.Fprintf(os.Stderr, "logger: slog handler panic: %v\n", recovered)
+	_, _ = fmt.Fprintln(os.Stderr, "logger: slog handler panic")
 }
 
 func commonAttrs(callID, callType string, model provider.LanguageModel) []slog.Attr {
@@ -416,11 +413,14 @@ func baseErrorAttrs(err error, capture CaptureOptions) []slog.Attr {
 	if err == nil {
 		return nil
 	}
-	return []slog.Attr{
+	attrs := []slog.Attr{
 		slog.String("ai_sdk.error.type", errorClass(err)),
 		slog.String("ai_sdk.error.type.go", errorType(err)),
-		slog.String("ai_sdk.error.message", boundString(err.Error(), capture.MaxStringLen)),
 	}
+	if capture.ErrorMessages {
+		attrs = append(attrs, slog.String("ai_sdk.error.message", boundString(err.Error(), capture.MaxStringLen)))
+	}
+	return attrs
 }
 
 func apiCallErrorAttrs(err *provider.APICallError, capture CaptureOptions) []slog.Attr {
@@ -452,6 +452,17 @@ func apiCallPartErrorAttrs(err *provider.APICallError, capture CaptureOptions) [
 	}
 	attrs := baseErrorAttrs(err, capture)
 	attrs = append(attrs, apiCallErrorAttrs(err, capture)...)
+	return attrs
+}
+
+func streamPartErrorAttrs(err *provider.APICallError, capture CaptureOptions) []slog.Attr {
+	if err != nil {
+		return apiCallPartErrorAttrs(err, capture)
+	}
+	attrs := []slog.Attr{slog.String("ai_sdk.error.type", "stream_part_error")}
+	if capture.ErrorMessages {
+		attrs = append(attrs, slog.String("ai_sdk.error.message", "provider stream emitted an error part"))
+	}
 	return attrs
 }
 

--- a/middleware/logger/logger_test.go
+++ b/middleware/logger/logger_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"log/slog"
+	"os"
 	"reflect"
 	"regexp"
 	"strings"
@@ -244,16 +246,77 @@ func TestMiddleware_GenerateErrorLogsAndPropagates(t *testing.T) {
 	assertAttr(t, attrs, "ai_sdk.outcome", outcomeError)
 	assertAttr(t, attrs, "ai_sdk.duration_ms", float64(50))
 	assertAttr(t, attrs, "ai_sdk.error.type", "unknown")
-	if !strings.Contains(attrs["ai_sdk.error.message"].(string), "sentinel failure") {
-		t.Fatalf("missing error message: %#v", attrs)
+	assertAttr(t, attrs, "ai_sdk.error.type.go", "*errors.errorString")
+	if _, ok := attrs["ai_sdk.error.message"]; ok {
+		t.Fatalf("default logging captured opaque error message: %#v", attrs)
 	}
+	if encoded := handler.JSON(t); strings.Contains(encoded, "sentinel failure") {
+		t.Fatalf("default records leaked opaque error message: %s", encoded)
+	}
+}
+
+func TestMiddleware_GenerateContextErrorsOmitMessages(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		errorType string
+	}{
+		{name: "cancellation", err: context.Canceled, errorType: "context_canceled"},
+		{name: "deadline", err: context.DeadlineExceeded, errorType: "context_deadline_exceeded"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := newTestHandler()
+			model := &mockModel{generateFunc: func(context.Context, provider.CallOptions) (*provider.GenerateResult, error) {
+				return nil, tc.err
+			}}
+			wrapped := Wrap(model, Options{Logger: slog.New(handler)})
+
+			_, err := wrapped.DoGenerate(context.Background(), provider.CallOptions{})
+			if !errors.Is(err, tc.err) {
+				t.Fatalf("expected context error, got %v", err)
+			}
+			attrs := handler.Records()[1].AttrsMap()
+			assertAttr(t, attrs, "ai_sdk.error.type", tc.errorType)
+			if _, ok := attrs["ai_sdk.error.message"]; ok {
+				t.Fatalf("default logging captured context error message: %#v", attrs)
+			}
+			if encoded := handler.JSON(t); strings.Contains(encoded, tc.err.Error()) {
+				t.Fatalf("default records leaked context error message: %s", encoded)
+			}
+		})
+	}
+}
+
+func TestMiddleware_ErrorMessageCaptureIsOptInAndBounded(t *testing.T) {
+	handler := newTestHandler()
+	sentinel := errors.New("sentinel failure with opaque details")
+	model := &mockModel{generateFunc: func(context.Context, provider.CallOptions) (*provider.GenerateResult, error) {
+		return nil, sentinel
+	}}
+	wrapped := Wrap(model, Options{
+		Logger: slog.New(handler),
+		Capture: CaptureOptions{
+			ErrorMessages: true,
+			MaxStringLen:  18,
+		},
+	})
+
+	_, err := wrapped.DoGenerate(context.Background(), provider.CallOptions{})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+	attrs := handler.Records()[1].AttrsMap()
+	assertAttr(t, attrs, "ai_sdk.error.message", "sent...[truncated]")
 }
 
 func TestMiddleware_APICallErrorURLRequiresExplicitCapture(t *testing.T) {
 	handler := newTestHandler()
 	secret := "TOP-SECRET-VALUE"
+	messageSecret := "OPAQUE-ERROR-MESSAGE-SECRET"
 	apiErr := provider.NewAPICallError(provider.APICallErrorOptions{
-		Message:    "failed",
+		Message:    "failed: " + messageSecret,
 		StatusCode: 401,
 		URL:        "https://example.test/v1/chat?access_token=" + secret,
 	})
@@ -266,8 +329,15 @@ func TestMiddleware_APICallErrorURLRequiresExplicitCapture(t *testing.T) {
 	if !errors.Is(err, apiErr) {
 		t.Fatalf("expected API error, got %v", err)
 	}
+	attrs := handler.Records()[1].AttrsMap()
+	assertAttr(t, attrs, "ai_sdk.error.type", "api_call_error")
+	assertAttr(t, attrs, "ai_sdk.error.status_code", int64(401))
+	assertAttr(t, attrs, "ai_sdk.error.retryable", false)
+	if _, ok := attrs["ai_sdk.error.message"]; ok {
+		t.Fatalf("default logging captured opaque API error message: %#v", attrs)
+	}
 	encoded := handler.JSON(t)
-	if strings.Contains(encoded, secret) || strings.Contains(encoded, "ai_sdk.error.url") {
+	if strings.Contains(encoded, secret) || strings.Contains(encoded, messageSecret) || strings.Contains(encoded, "ai_sdk.error.url") {
 		t.Fatalf("default records leaked API URL or secret: %s", encoded)
 	}
 }
@@ -348,7 +418,7 @@ func TestMiddleware_PanickingRedactorFallsBackToDefaultRedactor(t *testing.T) {
 		Logger: slog.New(handler),
 		Attrs:  []slog.Attr{slog.String("authorization", "Bearer "+secret)},
 		Redactor: RedactorFunc(func(context.Context, EventKind, []slog.Attr) []slog.Attr {
-			panic("boom")
+			panic(secret)
 		}),
 	})
 
@@ -366,10 +436,11 @@ func TestMiddleware_PanickingRedactorFallsBackToDefaultRedactor(t *testing.T) {
 
 func TestMiddleware_PanickingDynamicAttrsLogsDiagnostic(t *testing.T) {
 	handler := newTestHandler()
+	secret := "DYNAMIC-ATTRS-PANIC-SECRET"
 	wrapped := Wrap(&mockModel{}, Options{
 		Logger: slog.New(handler),
 		DynamicAttrs: func(context.Context) []slog.Attr {
-			panic("boom")
+			panic(secret)
 		},
 	})
 
@@ -377,8 +448,70 @@ func TestMiddleware_PanickingDynamicAttrsLogsDiagnostic(t *testing.T) {
 		t.Fatalf("DoGenerate returned error: %v", err)
 	}
 	encoded := handler.JSON(t)
+	if strings.Contains(encoded, secret) {
+		t.Fatalf("dynamic attrs panic leaked recovered message: %s", encoded)
+	}
 	if !strings.Contains(encoded, "dynamic attrs panic") {
 		t.Fatalf("expected dynamic attrs panic diagnostic: %s", encoded)
+	}
+}
+
+func TestMiddleware_PanickingHandlerOmitsRecoveredMessage(t *testing.T) {
+	fallback := newTestHandler()
+	previousDefault := slog.Default()
+	slog.SetDefault(slog.New(fallback))
+	defer slog.SetDefault(previousDefault)
+
+	secret := "SLOG-HANDLER-PANIC-SECRET"
+	wrapped := Wrap(&mockModel{}, Options{Logger: slog.New(panickingHandler{recovered: secret})})
+
+	if _, err := wrapped.DoGenerate(context.Background(), provider.CallOptions{}); err != nil {
+		t.Fatalf("DoGenerate returned error: %v", err)
+	}
+	encoded := fallback.JSON(t)
+	if strings.Contains(encoded, secret) {
+		t.Fatalf("slog handler panic leaked recovered message: %s", encoded)
+	}
+	if !strings.Contains(encoded, "slog handler panic") {
+		t.Fatalf("expected slog handler panic diagnostic: %s", encoded)
+	}
+}
+
+func TestMiddleware_NonComparablePanickingDefaultHandlerFailsOpen(t *testing.T) {
+	secret := "DEFAULT-SLOG-HANDLER-PANIC-SECRET"
+	previousDefault := slog.Default()
+	slog.SetDefault(slog.New(panickingHandler{recovered: secret, nonComparable: []string{"value"}}))
+	defer slog.SetDefault(previousDefault)
+
+	stderr, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create stderr pipe: %v", err)
+	}
+	previousStderr := os.Stderr
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = previousStderr
+		_ = stderr.Close()
+		_ = writer.Close()
+	}()
+
+	wrapped := Wrap(&mockModel{}, Options{})
+	if _, err := wrapped.DoGenerate(context.Background(), provider.CallOptions{}); err != nil {
+		t.Fatalf("DoGenerate returned error: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	os.Stderr = previousStderr
+	output, err := io.ReadAll(stderr)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if strings.Contains(string(output), secret) {
+		t.Fatalf("default slog handler panic leaked recovered message: %s", output)
+	}
+	if !strings.Contains(string(output), "slog handler panic") {
+		t.Fatalf("expected static slog handler panic diagnostic: %s", output)
 	}
 }
 
@@ -419,6 +552,18 @@ func TestMiddleware_CaptureOptionsOptInPayloadsStillRedactsKnownSecrets(t *testi
 		t.Fatalf("expected redaction marker in records: %s", encoded)
 	}
 }
+
+type panickingHandler struct {
+	recovered     any
+	nonComparable []string
+}
+
+func (panickingHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (h panickingHandler) Handle(context.Context, slog.Record) error {
+	panic(h.recovered)
+}
+func (h panickingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+func (h panickingHandler) WithGroup(string) slog.Handler      { return h }
 
 type mockModel struct {
 	provider_          string

--- a/middleware/logger/options.go
+++ b/middleware/logger/options.go
@@ -63,6 +63,8 @@ type CaptureOptions struct {
 	ResponseBody bool
 	// ProviderMetadata enables provider metadata capture.
 	ProviderMetadata bool
+	// ErrorMessages enables opaque error message capture.
+	ErrorMessages bool
 	// MaxStringLen bounds captured string values. Zero uses DefaultMaxStringLen.
 	MaxStringLen int
 	// MaxJSONBytes bounds captured JSON payloads. Zero uses DefaultMaxJSONBytes.

--- a/middleware/logger/stream.go
+++ b/middleware/logger/stream.go
@@ -114,14 +114,7 @@ streamLoop:
 	}
 
 	if summary.firstErrSet {
-		if summary.firstErr != nil {
-			attrs = append(attrs, apiCallPartErrorAttrs(summary.firstErr, l.opts.capture)...)
-		} else {
-			attrs = append(attrs,
-				slog.String("ai_sdk.error.type", "stream_part_error"),
-				slog.String("ai_sdk.error.message", "provider stream emitted an error part"),
-			)
-		}
+		attrs = append(attrs, streamPartErrorAttrs(summary.firstErr, l.opts.capture)...)
 		l.log(ctx, EventStreamError, l.opts.errorLevel, attrs...)
 		return
 	}
@@ -171,7 +164,7 @@ func (l *modelLogger) logStreamPart(ctx context.Context, callID string, model pr
 	level := l.opts.partLevel
 	if part.Type == provider.PartError {
 		level = l.opts.errorLevel
-		attrs = append(attrs, apiCallPartErrorAttrs(part.APICallError, l.opts.capture)...)
+		attrs = append(attrs, streamPartErrorAttrs(part.APICallError, l.opts.capture)...)
 	}
 	l.log(ctx, EventStreamPart, level, attrs...)
 }

--- a/middleware/logger/stream_test.go
+++ b/middleware/logger/stream_test.go
@@ -113,13 +113,22 @@ func TestMiddleware_StreamOpenErrorLogsAndPropagates(t *testing.T) {
 	if records[1].Message != string(EventStreamError) {
 		t.Fatalf("expected stream error record, got %s", records[1].Message)
 	}
-	assertAttr(t, records[1].AttrsMap(), "ai_sdk.success", false)
-	assertAttr(t, records[1].AttrsMap(), "ai_sdk.outcome", outcomeError)
+	attrs := records[1].AttrsMap()
+	assertAttr(t, attrs, "ai_sdk.success", false)
+	assertAttr(t, attrs, "ai_sdk.outcome", outcomeError)
+	assertAttr(t, attrs, "ai_sdk.error.type", "unknown")
+	if _, ok := attrs["ai_sdk.error.message"]; ok {
+		t.Fatalf("default logging captured opaque stream-open error message: %#v", attrs)
+	}
+	if encoded := handler.JSON(t); strings.Contains(encoded, "stream open failed") {
+		t.Fatalf("default records leaked opaque stream-open error message: %s", encoded)
+	}
 }
 
 func TestMiddleware_StreamPartErrorLogsTerminalError(t *testing.T) {
 	handler := newTestHandler()
-	apiErr := provider.NewAPICallError(provider.APICallErrorOptions{Message: "rate limited", StatusCode: 429})
+	messageSecret := "STREAM-PART-ERROR-MESSAGE-SECRET"
+	apiErr := provider.NewAPICallError(provider.APICallErrorOptions{Message: messageSecret, StatusCode: 429})
 	parts := []provider.StreamPart{
 		{Type: provider.PartTextDelta, Delta: "before"},
 		{Type: provider.PartError, APICallError: apiErr},
@@ -156,6 +165,60 @@ func TestMiddleware_StreamPartErrorLogsTerminalError(t *testing.T) {
 	assertAttr(t, attrs, "ai_sdk.stream.parts.error.count", int64(1))
 	assertAttr(t, attrs, "ai_sdk.error.status_code", int64(429))
 	assertAttr(t, attrs, "ai_sdk.error.retryable", true)
+	if _, ok := attrs["ai_sdk.error.message"]; ok {
+		t.Fatalf("default logging captured opaque stream-part error message: %#v", attrs)
+	}
+	if encoded := handler.JSON(t); strings.Contains(encoded, messageSecret) {
+		t.Fatalf("default records leaked opaque stream-part error message: %s", encoded)
+	}
+}
+
+func TestMiddleware_StreamPartErrorMessageCaptureIsOptIn(t *testing.T) {
+	messageSecret := "STREAM-PART-ERROR-MESSAGE-SECRET"
+	apiErr := provider.NewAPICallError(provider.APICallErrorOptions{Message: messageSecret, StatusCode: 500})
+	handler := newTestHandler()
+	wrapped := Wrap(streamModel([]provider.StreamPart{{Type: provider.PartError, APICallError: apiErr}}), Options{
+		Logger:  slog.New(handler),
+		Capture: CaptureOptions{ErrorMessages: true},
+	})
+
+	result, err := wrapped.DoStream(context.Background(), provider.CallOptions{})
+	if err != nil {
+		t.Fatalf("DoStream returned error: %v", err)
+	}
+	drainStream(result.Stream)
+
+	attrs := handler.Records()[1].AttrsMap()
+	message, ok := attrs["ai_sdk.error.message"].(string)
+	if !ok || !strings.Contains(message, messageSecret) {
+		t.Fatalf("missing opted-in stream-part error message: %#v", attrs)
+	}
+}
+
+func TestMiddleware_StreamPartLoggingClassifiesNilError(t *testing.T) {
+	handler := newTestHandler()
+	wrapped := Wrap(streamModel([]provider.StreamPart{{Type: provider.PartError}}), Options{
+		Logger:         slog.New(handler),
+		LogStreamParts: true,
+	})
+
+	result, err := wrapped.DoStream(context.Background(), provider.CallOptions{})
+	if err != nil {
+		t.Fatalf("DoStream returned error: %v", err)
+	}
+	drainStream(result.Stream)
+
+	records := handler.Records()
+	if len(records) != 3 {
+		t.Fatalf("expected start, part, and terminal records, got %d", len(records))
+	}
+	for _, record := range records[1:] {
+		attrs := record.AttrsMap()
+		assertAttr(t, attrs, "ai_sdk.error.type", "stream_part_error")
+		if _, ok := attrs["ai_sdk.error.message"]; ok {
+			t.Fatalf("default logging captured stream-part error message: %#v", attrs)
+		}
+	}
 }
 
 func TestMiddleware_StreamContextCancellationClosesIdleStream(t *testing.T) {
@@ -187,6 +250,45 @@ func TestMiddleware_StreamContextCancellationClosesIdleStream(t *testing.T) {
 	attrs := records[1].AttrsMap()
 	assertAttr(t, attrs, "ai_sdk.outcome", outcomeCancelled)
 	assertAttr(t, attrs, "ai_sdk.error.type", "context_canceled")
+	if _, ok := attrs["ai_sdk.error.message"]; ok {
+		t.Fatalf("default logging captured context cancellation message: %#v", attrs)
+	}
+}
+
+func TestMiddleware_StreamContextDeadlineOmitsMessage(t *testing.T) {
+	handler := newTestHandler()
+	upstream := make(chan provider.StreamPart)
+	model := &mockModel{streamFunc: func(context.Context, provider.CallOptions) (*provider.StreamResult, error) {
+		return &provider.StreamResult{Stream: upstream}, nil
+	}}
+	ctx, cancel := context.WithTimeout(context.Background(), time.Nanosecond)
+	defer cancel()
+	<-ctx.Done()
+	wrapped := Wrap(model, Options{Logger: slog.New(handler)})
+
+	result, err := wrapped.DoStream(ctx, provider.CallOptions{})
+	if err != nil {
+		t.Fatalf("DoStream returned error: %v", err)
+	}
+	select {
+	case _, ok := <-result.Stream:
+		if ok {
+			t.Fatal("expected stream to close after deadline")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for deadline stream to close")
+	}
+
+	records := waitForRecords(t, handler, 2)
+	if records[1].Message != string(EventStreamError) {
+		t.Fatalf("expected stream error terminal record, got %s", records[1].Message)
+	}
+	attrs := records[1].AttrsMap()
+	assertAttr(t, attrs, "ai_sdk.outcome", outcomeTimeout)
+	assertAttr(t, attrs, "ai_sdk.error.type", "context_deadline_exceeded")
+	if _, ok := attrs["ai_sdk.error.message"]; ok {
+		t.Fatalf("default logging captured context deadline message: %#v", attrs)
+	}
 }
 
 func TestMiddleware_StreamContextCancellationDoesNotLeak(t *testing.T) {
@@ -263,7 +365,7 @@ func TestMiddleware_StreamPartLoggingWithProviderMetadataDoesNotLeakAPICallError
 	parts := []provider.StreamPart{{
 		Type: provider.PartError,
 		APICallError: provider.NewAPICallError(provider.APICallErrorOptions{
-			Message:           "failed",
+			Message:           secret,
 			StatusCode:        500,
 			URL:               "https://example.test/v1?access_token=" + secret,
 			RequestBodyValues: json.RawMessage(`{"secret":"STREAM-API-SECRET"}`),

--- a/openspec/specs/structured-logging-middleware/spec.md
+++ b/openspec/specs/structured-logging-middleware/spec.md
@@ -45,7 +45,7 @@ The `Options` type SHALL include:
 - `LogStreamParts bool`
 - `Clock func() time.Time`
 
-The `CaptureOptions` type SHALL include explicit opt-in controls for `Inputs`, `Outputs`, `Reasoning`, `ToolInputs`, `ToolOutputs`, `Files`, `RawChunks`, `Headers`, `ProviderOptions`, `RequestBody`, `ResponseBody`, and `ProviderMetadata`, plus bounded payload controls `MaxStringLen` and `MaxJSONBytes`.
+The `CaptureOptions` type SHALL include explicit opt-in controls for `Inputs`, `Outputs`, `Reasoning`, `ToolInputs`, `ToolOutputs`, `Files`, `RawChunks`, `Headers`, `ProviderOptions`, `RequestBody`, `ResponseBody`, `ProviderMetadata`, and `ErrorMessages`, plus bounded payload controls `MaxStringLen` and `MaxJSONBytes`.
 
 The package SHALL expose a `Redactor` interface, a `RedactorFunc` adapter, `DefaultRedactor() Redactor`, and `DefaultRedactorWithExtraKeys(keys ...string) Redactor`.
 
@@ -111,7 +111,7 @@ The logger SHALL use documented stable keys for optional captured payloads and S
 
 ### Requirement: Privacy-first capture policy
 
-By default, the logger SHALL NOT log prompt/message content, generated text, reasoning text, tool inputs, tool outputs, file data, raw chunks, request bodies, response bodies, headers, provider options, or provider metadata.
+By default, the logger SHALL NOT log prompt/message content, generated text, reasoning text, tool inputs, tool outputs, file data, raw chunks, request bodies, response bodies, headers, provider options, provider metadata, or opaque error messages.
 
 By default, the logger MAY log safe scalar summaries and counts, including provider/model identity, transport identity when a routed backend differs, duration, outcome, success/failure, max output tokens, temperature, top-p, top-k, seed, reasoning effort value, stop sequence count, tool count, response format type, usage totals/subfields, finish reason, warning count/types, response metadata, stream part counts, and stream time to first content.
 
@@ -129,6 +129,19 @@ Sensitive fields SHALL only become eligible for logging when the corresponding `
 - **WHEN** `Capture.Inputs`, `Capture.Headers`, and `Capture.ProviderOptions` are enabled
 - **THEN** prompt, header, and provider option attributes MAY be emitted
 - **AND** those attributes SHALL still pass through the configured redactor before logging
+
+#### Scenario: Metadata-only errors omit opaque messages
+
+- **WHEN** a unary error, stream-open error, streamed error part, context cancellation, or timeout contains an opaque message
+- **AND** `Capture.ErrorMessages` is false
+- **THEN** no emitted record SHALL contain the opaque message
+- **AND** error class/type, HTTP status, retryability, operation, outcome, timing, and model identity metadata SHALL remain available when applicable
+
+#### Scenario: Error message capture is opt-in
+
+- **WHEN** `Capture.ErrorMessages` is true
+- **THEN** the bounded opaque error message MAY be emitted
+- **AND** the message SHALL still pass through the configured redactor before logging
 
 #### Scenario: Captured payloads are bounded
 
@@ -166,7 +179,7 @@ For each generate call, the middleware SHALL:
 1. Build start attributes from `middleware.WrapGenerateParams`, including call type, provider, model, safe request summary, and any opted-in captured request fields.
 2. Log `EventGenerateStart` before invoking the inner call.
 3. Invoke `p.DoGenerate(ctx)` exactly once.
-4. On returned error, log `EventGenerateError` with duration, `ai_sdk.outcome="error"`, `ai_sdk.success=false`, stable error classification/message, optional Go error type, and API-call status/retryability when available; then return the original error unchanged.
+4. On returned error, log `EventGenerateError` with duration, `ai_sdk.outcome="error"`, `ai_sdk.success=false`, stable error classification, Go error type, API-call status/retryability when available, and a bounded opaque message only when `Capture.ErrorMessages` is true; then return the original error unchanged.
 5. On success, log `EventGenerateFinish` with duration, `ai_sdk.outcome="success"`, `ai_sdk.success=true`, finish reason, usage, warning count/types, response metadata, and opted-in captured response fields; then return the original `*provider.GenerateResult` unchanged.
 
 Serialization, capture, redaction, or logging failures SHALL NOT fail the model call. Best-effort serialization failures SHALL be represented as `ai_sdk.serialization_error` attrs when possible.


### PR DESCRIPTION
## Summary

- add `CaptureOptions.ErrorMessages` as an explicit, default-off control for opaque error text
- apply the policy consistently to unary errors, stream-open failures, streamed error parts, cancellation, and timeouts while retaining structured error metadata
- prevent recovered hook and slog-handler panic values from bypassing metadata-only logging
- document the distinction between bounded structured metadata and opaque messages

## Tests And Specs

- add sentinel-based coverage for unary, API, streaming, context, per-part, panic, opt-in, and fail-open paths
- update package documentation, the structured logging guide, and the canonical OpenSpec specification

## Validation

- `cd middleware/logger && go test ./...`
- `cd middleware/logger && go test -race ./...`
- `cd middleware/logger && go vet ./...`
- `mise run test-short`
- `mise run vet`
- `mise run lint`
- `mise run lint-docs`
- `openspec validate --all`
- `mise run validate-parity-baseline`

## Residual Risk

- error messages that were previously emitted by default now require `ErrorMessages: true`; this is intentional for metadata-only privacy

Closes #22
