### PR TITLE
fix(anthropic): request Vertex OAuth scope

### DIFF
--- a/providers/anthropic/model.go
+++ b/providers/anthropic/model.go
@@ -14,6 +14,10 @@ import (
 
 const specVersion = "v4"
 
+const vertexCloudPlatformScope = "https://www.googleapis.com/auth/cloud-platform"
+
+var vertexGoogleAuth = vertexsdk.WithGoogleAuth
+
 type model struct {
 	client       anthropic.Client
 	modelID      string
@@ -82,7 +86,7 @@ func vertexAuth(ctx context.Context, location, projectID string) (opt option.Req
 			opt = nil
 		}
 	}()
-	return vertexsdk.WithGoogleAuth(ctx, location, projectID), nil
+	return vertexGoogleAuth(ctx, location, projectID, vertexCloudPlatformScope), nil
 }
 
 func (m *model) SpecificationVersion() string               { return specVersion }

--- a/providers/anthropic/model_test.go
+++ b/providers/anthropic/model_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -66,4 +67,20 @@ func TestVertexAuth_PanicRecovery(t *testing.T) {
 		require.NotNil(t, inner, "expected wrapped inner error from panic recovery")
 		assert.Contains(t, inner.Error(), "failed to find default credentials")
 	})
+}
+
+func TestVertexAuth_RequestsCloudPlatformScope(t *testing.T) {
+	originalGoogleAuth := vertexGoogleAuth
+	t.Cleanup(func() { vertexGoogleAuth = originalGoogleAuth })
+
+	var gotScopes []string
+	vertexGoogleAuth = func(_ context.Context, _, _ string, scopes ...string) option.RequestOption {
+		gotScopes = append([]string(nil), scopes...)
+		return option.WithAPIKey("test-key")
+	}
+
+	opt, err := vertexAuth(context.Background(), "us-east5", "my-project")
+	require.NoError(t, err)
+	require.NotNil(t, opt)
+	assert.Equal(t, []string{vertexCloudPlatformScope}, gotScopes)
 }


### PR DESCRIPTION
Problem:

Vertex calls made through the Anthropic provider load Application Default Credentials without an OAuth scope. Service-account credentials therefore fail token exchange with `invalid_scope` before inference, while other Vertex clients that request the Cloud Platform scope continue to work.

Solution:

Request `https://www.googleapis.com/auth/cloud-platform` when constructing Vertex authentication. This matches the registered Vercel AI SDK baseline, whose Google Vertex provider configures the same scope. Add a focused regression test that verifies the scope passed to the upstream Vertex auth helper.

Security Impact:

None. The change supplies the standard OAuth scope required to mint the existing service account's access token; IAM permissions remain unchanged.

Testing:

- `cd providers/anthropic && go test ./...`
- `mise run vet`
- `mise run lint`
- `git diff --check`
