### PR TITLE
fix(fallback): expose provider attempts

### DIFF
--- a/fallback/fallback.go
+++ b/fallback/fallback.go
@@ -3,7 +3,9 @@ package fallback
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
+	"time"
 
 	"github.com/grafana/ai-sdk/provider"
 )
@@ -17,7 +19,21 @@ var ErrNoCandidates = errors.New("fallback: at least one candidate is required")
 type Model struct {
 	candidates []provider.LanguageModel
 	decider    func(error) bool
+	observer   AttemptObserver
 }
+
+// Attempt describes one candidate invocation made by a fallback model.
+type Attempt struct {
+	Index      int
+	Provider   string
+	ModelID    string
+	StartedAt  time.Time
+	FinishedAt time.Time
+	Err        error
+}
+
+// AttemptObserver observes a completed fallback candidate attempt.
+type AttemptObserver func(context.Context, Attempt)
 
 // New creates a FallbackModel from the given candidates.
 // Returns ErrNoCandidates if no candidates are provided.
@@ -38,47 +54,59 @@ func (m *Model) WithDecider(fn func(error) bool) *Model {
 	return m
 }
 
+// WithAttemptObserver registers a callback invoked after each candidate
+// attempt. Index is one-based. For streams, an attempt finishes when the first
+// part arrives, the stream closes, or the provider returns an error.
+func (m *Model) WithAttemptObserver(fn AttemptObserver) *Model {
+	m.observer = fn
+	return m
+}
+
 func (m *Model) SpecificationVersion() string               { return m.candidates[0].SpecificationVersion() }
 func (m *Model) Provider() string                           { return m.candidates[0].Provider() }
 func (m *Model) ModelID() string                            { return m.candidates[0].ModelID() }
 func (m *Model) SupportedURLs() map[string][]*regexp.Regexp { return m.candidates[0].SupportedURLs() }
 
 func (m *Model) DoGenerate(ctx context.Context, params provider.CallOptions) (*provider.GenerateResult, error) {
-	var lastErr error
-	for _, c := range m.candidates {
+	var failures []failedAttempt
+	for i, c := range m.candidates {
 		if ctx.Err() != nil {
-			if lastErr != nil {
-				return nil, lastErr
+			if len(failures) > 0 {
+				return nil, failedAttemptsError(failures)
 			}
 			return nil, ctx.Err()
 		}
+		startedAt := time.Now()
 		result, err := c.DoGenerate(ctx, params)
+		m.observeAttempt(ctx, i, c, startedAt, err)
 		if err == nil {
 			return result, nil
 		}
-		lastErr = err
+		failures = append(failures, failedAttempt{candidate: c, err: err})
 		if !m.decider(err) {
-			return nil, err
+			return nil, failedAttemptsError(failures)
 		}
 	}
-	return nil, lastErr
+	return nil, failedAttemptsError(failures)
 }
 
 func (m *Model) DoStream(ctx context.Context, params provider.CallOptions) (*provider.StreamResult, error) {
-	var lastErr error
-	for _, c := range m.candidates {
+	var failures []failedAttempt
+	for i, c := range m.candidates {
 		if ctx.Err() != nil {
-			if lastErr != nil {
-				return nil, lastErr
+			if len(failures) > 0 {
+				return nil, failedAttemptsError(failures)
 			}
 			return nil, ctx.Err()
 		}
 
+		startedAt := time.Now()
 		result, err := c.DoStream(ctx, params)
 		if err != nil {
-			lastErr = err
+			m.observeAttempt(ctx, i, c, startedAt, err)
+			failures = append(failures, failedAttempt{candidate: c, err: err})
 			if !m.decider(err) {
-				return nil, err
+				return nil, failedAttemptsError(failures)
 			}
 			continue
 		}
@@ -92,13 +120,15 @@ func (m *Model) DoStream(ctx context.Context, params provider.CallOptions) (*pro
 				for range result.Stream {
 				}
 			}()
-			if lastErr != nil {
-				return nil, lastErr
+			m.observeAttempt(ctx, i, c, startedAt, ctx.Err())
+			if len(failures) > 0 {
+				return nil, failedAttemptsError(failures)
 			}
 			return nil, ctx.Err()
 		}
 
 		if !ok {
+			m.observeAttempt(ctx, i, c, startedAt, nil)
 			return result, nil
 		}
 
@@ -119,13 +149,15 @@ func (m *Model) DoStream(ctx context.Context, params provider.CallOptions) (*pro
 				})
 			}
 			var partErr error = apiErr
-			lastErr = partErr
+			m.observeAttempt(ctx, i, c, startedAt, partErr)
+			failures = append(failures, failedAttempt{candidate: c, err: partErr})
 			if !m.decider(partErr) {
-				return nil, partErr
+				return nil, failedAttemptsError(failures)
 			}
 			continue
 		}
 
+		m.observeAttempt(ctx, i, c, startedAt, nil)
 		ch := make(chan provider.StreamPart, 64)
 		go func() {
 			defer close(ch)
@@ -140,7 +172,42 @@ func (m *Model) DoStream(ctx context.Context, params provider.CallOptions) (*pro
 			Response: result.Response,
 		}, nil
 	}
-	return nil, lastErr
+	return nil, failedAttemptsError(failures)
+}
+
+type failedAttempt struct {
+	candidate provider.LanguageModel
+	err       error
+}
+
+func (m *Model) observeAttempt(ctx context.Context, index int, candidate provider.LanguageModel, startedAt time.Time, err error) {
+	if m.observer == nil {
+		return
+	}
+	m.observer(ctx, Attempt{
+		Index:      index + 1,
+		Provider:   candidate.Provider(),
+		ModelID:    candidate.ModelID(),
+		StartedAt:  startedAt,
+		FinishedAt: time.Now(),
+		Err:        err,
+	})
+}
+
+func failedAttemptsError(failures []failedAttempt) error {
+	if len(failures) == 0 {
+		return nil
+	}
+	if len(failures) == 1 {
+		return failures[0].err
+	}
+
+	errs := make([]error, 0, len(failures))
+	for i := len(failures) - 1; i >= 0; i-- {
+		failure := failures[i]
+		errs = append(errs, fmt.Errorf("fallback: provider %q model %q: %w", failure.candidate.Provider(), failure.candidate.ModelID(), failure.err))
+	}
+	return errors.Join(errs...)
 }
 
 // defaultDecider returns true (try next candidate) for retryable API errors

--- a/fallback/fallback_test.go
+++ b/fallback/fallback_test.go
@@ -150,22 +150,61 @@ func TestDoGenerate(t *testing.T) {
 		assert.False(t, secondaryCalled, "secondary should not be called when decider rejects")
 	})
 
-	t.Run("AllFail_ReturnsLastError", func(t *testing.T) {
+	t.Run("AllFail_PreservesEveryAttempt", func(t *testing.T) {
+		primaryErr := errors.New("primary error")
+		secondaryErr := errors.New("secondary error")
 		primary := &mockModel{
+			providerName: "bedrock",
+			modelID:      "bedrock-model",
 			doGenerate: func(_ context.Context, _ provider.CallOptions) (*provider.GenerateResult, error) {
-				return nil, errors.New("primary error")
+				return nil, primaryErr
 			},
 		}
 		secondary := &mockModel{
+			providerName: "vertex",
+			modelID:      "vertex-model",
 			doGenerate: func(_ context.Context, _ provider.CallOptions) (*provider.GenerateResult, error) {
-				return nil, errors.New("secondary error")
+				return nil, secondaryErr
 			},
 		}
 
 		m := mustNew(t, primary, secondary)
 		_, err := m.DoGenerate(context.Background(), provider.CallOptions{})
 		require.Error(t, err)
-		assert.Equal(t, "secondary error", err.Error())
+		assert.ErrorIs(t, err, primaryErr)
+		assert.ErrorIs(t, err, secondaryErr)
+		assert.Contains(t, err.Error(), `provider "vertex" model "vertex-model": secondary error`)
+		assert.Contains(t, err.Error(), `provider "bedrock" model "bedrock-model": primary error`)
+	})
+
+	t.Run("AttemptObserver", func(t *testing.T) {
+		primaryErr := errors.New("primary error")
+		primary := &mockModel{
+			providerName: "bedrock",
+			modelID:      "bedrock-model",
+			doGenerate: func(_ context.Context, _ provider.CallOptions) (*provider.GenerateResult, error) {
+				return nil, primaryErr
+			},
+		}
+		secondary := &mockModel{
+			providerName: "vertex",
+			modelID:      "vertex-model",
+			doGenerate: func(_ context.Context, _ provider.CallOptions) (*provider.GenerateResult, error) {
+				return &provider.GenerateResult{}, nil
+			},
+		}
+
+		var attempts []Attempt
+		m := mustNew(t, primary, secondary).WithAttemptObserver(func(_ context.Context, attempt Attempt) {
+			attempts = append(attempts, attempt)
+		})
+		_, err := m.DoGenerate(context.Background(), provider.CallOptions{})
+		require.NoError(t, err)
+		require.Len(t, attempts, 2)
+		assert.Equal(t, Attempt{Index: 1, Provider: "bedrock", ModelID: "bedrock-model", StartedAt: attempts[0].StartedAt, FinishedAt: attempts[0].FinishedAt, Err: primaryErr}, attempts[0])
+		assert.Equal(t, Attempt{Index: 2, Provider: "vertex", ModelID: "vertex-model", StartedAt: attempts[1].StartedAt, FinishedAt: attempts[1].FinishedAt}, attempts[1])
+		assert.False(t, attempts[0].FinishedAt.Before(attempts[0].StartedAt))
+		assert.False(t, attempts[1].FinishedAt.Before(attempts[1].StartedAt))
 	})
 
 	t.Run("ContextCancelled", func(t *testing.T) {
@@ -190,6 +229,42 @@ func TestDoGenerate(t *testing.T) {
 }
 
 func TestDoStream(t *testing.T) {
+	t.Run("AttemptObserver", func(t *testing.T) {
+		primaryErr := provider.NewAPICallError(provider.APICallErrorOptions{Message: "primary error", StatusCode: 503})
+		primaryCh := make(chan provider.StreamPart, 1)
+		primaryCh <- provider.StreamPart{Type: provider.PartError, APICallError: primaryErr}
+		close(primaryCh)
+		secondaryCh := make(chan provider.StreamPart)
+		close(secondaryCh)
+
+		primary := &mockModel{
+			providerName: "bedrock",
+			modelID:      "bedrock-model",
+			doStream: func(_ context.Context, _ provider.CallOptions) (*provider.StreamResult, error) {
+				return &provider.StreamResult{Stream: primaryCh}, nil
+			},
+		}
+		secondary := &mockModel{
+			providerName: "vertex",
+			modelID:      "vertex-model",
+			doStream: func(_ context.Context, _ provider.CallOptions) (*provider.StreamResult, error) {
+				return &provider.StreamResult{Stream: secondaryCh}, nil
+			},
+		}
+
+		var attempts []Attempt
+		m := mustNew(t, primary, secondary).WithAttemptObserver(func(_ context.Context, attempt Attempt) {
+			attempts = append(attempts, attempt)
+		})
+		_, err := m.DoStream(context.Background(), provider.CallOptions{})
+		require.NoError(t, err)
+		require.Len(t, attempts, 2)
+		assert.Equal(t, "bedrock", attempts[0].Provider)
+		assert.ErrorIs(t, attempts[0].Err, primaryErr)
+		assert.Equal(t, "vertex", attempts[1].Provider)
+		assert.NoError(t, attempts[1].Err)
+	})
+
 	t.Run("PrimarySyncError_SecondarySucceeds", func(t *testing.T) {
 		ch := make(chan provider.StreamPart)
 		close(ch)


### PR DESCRIPTION
Problem:

`fallback.Model` returns only the final candidate error and exposes the primary candidate through `Provider()`/`ModelID()`. When every provider fails, consumers can therefore record a primary Bedrock provider alongside a terminal Vertex error without any evidence that both providers were attempted.

The registered Vercel AI SDK 7.0.44 baseline has no equivalent multi-provider fallback primitive, so this is a Go-specific fallback observability fix rather than a parity change.

Solution:

- Preserve every failed candidate as a joined error annotated with provider and model, with the terminal failure first.
- Add `WithAttemptObserver` so consumers can emit one span or log per completed candidate attempt without adding an observability dependency to the root SDK module.
- Keep single-attempt errors unchanged and preserve `errors.Is`/`errors.As` behavior.
- Cover generate and stream fallback attempts.

Security Impact:

None.

Testing:

- `mise run fmt` (passed)
- `go test ./fallback` (passed)
- `go vet ./fallback` (passed)
- `mise run lint` (passed across all modules; zero issues)
- `git diff --check` (passed)
