### PR TITLE
fix(provider): decode tool-result file data unions

### DIFF
--- a/convert_test.go
+++ b/convert_test.go
@@ -421,7 +421,7 @@ func TestConvertToModelMessages_ToolModelOutput(t *testing.T) {
 		Type: provider.ToolOutputContent,
 		Content: []provider.ToolResultContentValue{
 			{Type: provider.ToolContentText, Text: "weather report"},
-			{Type: provider.ToolContentFileData, Data: "aGVsbG8=", MediaType: "image/png"},
+			{Type: provider.ToolContentFile, Data: &provider.DataContent{Base64: "aGVsbG8="}, MediaType: "image/png"},
 		},
 	}
 

--- a/gateway/providerwire/request_test.go
+++ b/gateway/providerwire/request_test.go
@@ -45,6 +45,25 @@ func TestDecodeCallOptions_UpstreamGatewayBody(t *testing.T) {
 	}, opts.Prompt[1].Content)
 }
 
+func TestDecodeCallOptions_UpstreamToolResultFileData(t *testing.T) {
+	body := []byte(`{"prompt":[{"role":"tool","content":[{` +
+		`"type":"tool-result","toolCallId":"call-1","toolName":"weather",` +
+		`"output":{"type":"content","value":[` +
+		`{"type":"text","text":"72 degrees and sunny"},` +
+		`{"type":"file","data":{"type":"data","data":"iVBORw0KGgo="},"mediaType":"image/png"}` +
+		`]}}]}]}`)
+
+	opts, err := DecodeCallOptions(body)
+	require.NoError(t, err)
+	require.Len(t, opts.Prompt, 1)
+	require.Len(t, opts.Prompt[0].Content, 1)
+	require.NotNil(t, opts.Prompt[0].Content[0].Output)
+	assert.Equal(t, []provider.ToolResultContentValue{
+		{Type: provider.ToolContentText, Text: "72 degrees and sunny"},
+		{Type: provider.ToolContentFile, Data: &provider.DataContent{Base64: "iVBORw0KGgo="}, MediaType: "image/png"},
+	}, opts.Prompt[0].Content[0].Output.Content)
+}
+
 // TestEncodeDecodeCallOptions_FullRoundTrip asserts every notable
 // CallOptions field round-trips losslessly through wire encoding.
 func TestEncodeDecodeCallOptions_FullRoundTrip(t *testing.T) {

--- a/openspec/specs/typed-string-enums/spec.md
+++ b/openspec/specs/typed-string-enums/spec.md
@@ -82,11 +82,17 @@ The `provider` package SHALL define a `SourceType` typed string with constants: 
 
 ### Requirement: ToolResultContentType typed string enum
 
-The `provider` package SHALL define a `ToolResultContentType` typed string with constants: `ToolContentText` ("text"), `ToolContentFileData` ("file-data"), `ToolContentFileURL` ("file-url"), `ToolContentFileReference` ("file-reference"), `ToolContentCustom` ("custom"). These match upstream V4 exactly -- images are represented as `ToolContentFileData` with an image mediaType, not as separate image-specific types. The `ToolResultContentValue.Type` field SHALL be typed as `ToolResultContentType`. The `ToolResultContentValue.ProviderReference` field (json `"providerReference"`) SHALL hold the provider-specific reference, matching the upstream V4 `providerReference` field.
+The `provider` package SHALL define a `ToolResultContentType` typed string with canonical constants: `ToolContentText` ("text"), `ToolContentFile` ("file"), and `ToolContentCustom` ("custom"). The `ToolResultContentValue.Type` field SHALL be typed as `ToolResultContentType`, and file values SHALL carry `Data *DataContent` using the LanguageModelV4 tagged data union.
+
+The legacy constants `ToolContentFileData` ("file-data"), `ToolContentFileURL` ("file-url"), and `ToolContentFileReference` ("file-reference") SHALL remain available to recognize legacy wire input. Decoding SHALL normalize them to `ToolContentFile`, and marshaling SHALL emit `"file"`.
 
 #### Scenario: ToolResultContentValue uses typed constant
-- **WHEN** a test constructs `ToolResultContentValue{Type: "file-data", Data: "base64data"}`
-- **THEN** it SHALL use `ToolContentFileData` instead of the bare string
+- **WHEN** a test constructs a canonical file content value
+- **THEN** it SHALL use `ToolContentFile` instead of the bare string `"file"`
+
+#### Scenario: legacy discriminator normalization
+- **WHEN** a legacy `"file-data"`, `"file-url"`, or `"file-reference"` value is decoded
+- **THEN** its `Type` SHALL normalize to `ToolContentFile`
 
 ### Requirement: GenerateContentType typed string enum
 

--- a/openspec/specs/v4-tool-result-alignment/spec.md
+++ b/openspec/specs/v4-tool-result-alignment/spec.md
@@ -25,7 +25,7 @@ The `ToolResultContentValue` struct SHALL support the following `Type` values:
 - `"file"` -- file content with `Data *DataContent`, `MediaType`, and optional `Filename`
 - `"custom"` -- custom provider-specific content with `ProviderOptions` only
 
-File content SHALL use the LanguageModelV4 tagged `DataContent` union for inline data, URLs, provider references, and inline text. Images SHALL use `"file"` with an image media type (e.g. `image/png`).
+File content SHALL require both `Data` and `MediaType` and use the LanguageModelV4 tagged `DataContent` union for inline data, URLs, provider references, and inline text. `MediaType` SHALL accept a full IANA media type, a top-level segment, or an equivalent `*`-subtype wildcard. Images SHALL use `"file"` with an image media type (e.g. `image/png`).
 
 The legacy `"file-data"`, `"file-url"`, and `"file-reference"` wire discriminators SHALL remain accepted during decoding and SHALL normalize to `"file"`. Marshaling SHALL emit the canonical `"file"` discriminator and tagged data union.
 

--- a/openspec/specs/v4-tool-result-alignment/spec.md
+++ b/openspec/specs/v4-tool-result-alignment/spec.md
@@ -21,31 +21,33 @@ This field applies to stream parts of type `PartToolResult`.
 ### Requirement: ToolResultContentValue expanded types
 
 The `ToolResultContentValue` struct SHALL support the following `Type` values:
-- `"text"` -- text content (existing)
-- `"file-data"` -- base64-encoded file data with `Data`, `MediaType`, and optional `Filename`
-- `"file-url"` -- file referenced by URL with `URL`
-- `"file-reference"` -- file referenced by provider-specific reference with `ProviderReference`
+- `"text"` -- text content
+- `"file"` -- file content with `Data *DataContent`, `MediaType`, and optional `Filename`
 - `"custom"` -- custom provider-specific content with `ProviderOptions` only
 
-Images are represented as `"file-data"` with an image media type (e.g. `image/png`).
+File content SHALL use the LanguageModelV4 tagged `DataContent` union for inline data, URLs, provider references, and inline text. Images SHALL use `"file"` with an image media type (e.g. `image/png`).
 
-The `FileID json.RawMessage` field SHALL be renamed to `ProviderReference map[string]string` (json tag `"providerReference,omitempty"`) to match upstream V4's `SharedV4ProviderReference` semantics where keys are provider names and values are provider-specific identifiers.
+The legacy `"file-data"`, `"file-url"`, and `"file-reference"` wire discriminators SHALL remain accepted during decoding and SHALL normalize to `"file"`. Marshaling SHALL emit the canonical `"file"` discriminator and tagged data union.
 
-#### Scenario: file-data content value
-- **WHEN** a `ToolResultContentValue` is constructed with `Type: "file-data"`, `Data: "<base64>"`, `MediaType: "application/pdf"`, and `Filename: "report.pdf"`
-- **THEN** all fields SHALL be accessible and the struct SHALL marshal correctly
+#### Scenario: inline file data content value
+- **WHEN** a `ToolResultContentValue` is constructed with `Type: "file"`, `Data: &DataContent{Base64: "<base64>"}`, `MediaType: "application/pdf"`, and `Filename: "report.pdf"`
+- **THEN** it SHALL marshal with `type: "file"` and `data: {type: "data", data: "<base64>"}`
 
-#### Scenario: image content value uses file-data
-- **WHEN** a `ToolResultContentValue` holds image content with `Type: "file-data"`, `Data: "<base64>"`, and `MediaType: "image/png"`
-- **THEN** the data and media type SHALL be preserved
+#### Scenario: image content value uses file
+- **WHEN** a `ToolResultContentValue` holds image content with `Type: "file"`, base64 `DataContent`, and `MediaType: "image/png"`
+- **THEN** the tagged data and media type SHALL be preserved
 
-#### Scenario: file-url content value
-- **WHEN** a `ToolResultContentValue` is constructed with `Type: "file-url"` and `URL: "https://example.com/file.pdf"`
-- **THEN** the URL field SHALL be present in the marshaled output
+#### Scenario: file URL content value
+- **WHEN** a `ToolResultContentValue` is constructed with `Type: "file"` and `Data: &DataContent{URL: "https://example.com/file.pdf"}`
+- **THEN** the URL SHALL serialize through the tagged data union
 
-#### Scenario: file-reference content value
-- **WHEN** a `ToolResultContentValue` is constructed with `Type: "file-reference"` and `ProviderReference: map[string]string{"openai": "file-abc123"}`
-- **THEN** the ProviderReference SHALL serialize as `{"providerReference": {"openai": "file-abc123"}}`
+#### Scenario: file provider-reference content value
+- **WHEN** a `ToolResultContentValue` is constructed with `Type: "file"` and `Data.Reference` containing `{"openai":"file-abc123"}`
+- **THEN** the reference SHALL serialize through the tagged data union
+
+#### Scenario: legacy raw base64 content value
+- **WHEN** a legacy `{"type":"file-data","data":"<base64>"}` value is decoded
+- **THEN** it SHALL normalize to `ToolContentFile` with `DataContent.Base64` populated
 
 #### Scenario: custom content value
 - **WHEN** a `ToolResultContentValue` is constructed with `Type: "custom"` and `ProviderOptions` containing provider-specific data

--- a/provider/content.go
+++ b/provider/content.go
@@ -7,6 +7,15 @@ import (
 	"fmt"
 )
 
+type dataContentVariant string
+
+const (
+	dataContentVariantData dataContentVariant = "data"
+	dataContentVariantURL  dataContentVariant = "url"
+	dataContentVariantRef  dataContentVariant = "reference"
+	dataContentVariantText dataContentVariant = "text"
+)
+
 // DataContent represents file data as bytes, base64, a URL, a provider reference, or inline text.
 // Exactly one of Bytes, Base64, URL, Reference, or Text should be set.
 type DataContent struct {
@@ -18,7 +27,8 @@ type DataContent struct {
 	Reference json.RawMessage `json:"reference,omitempty"`
 	// Text carries the upstream `{type:"text",text}` variant, an inline text
 	// document.
-	Text string `json:"text,omitempty"`
+	Text    string `json:"text,omitempty"`
+	variant dataContentVariant
 }
 
 // MarshalJSON emits the upstream Vercel AI SDK LanguageModelV4 tagged file-data
@@ -32,29 +42,46 @@ type DataContent struct {
 // This supersedes the legacy Go-to-Go `{"bytes"|"base64"|"url":...}` emitted
 // form. Decoding remains tolerant of both shapes (see [DataContent.UnmarshalJSON]).
 // See openspec change provider-wire-upstream-full-compat.
+// Base64DataContent constructs inline base64 file data, including an empty payload.
+func Base64DataContent(data string) DataContent {
+	if data == "" {
+		return DataContent{Bytes: []byte{}}
+	}
+	return DataContent{Base64: data}
+}
+
+// IsData reports whether d represents inline bytes or base64 data.
+func (d DataContent) IsData() bool {
+	return d.Bytes != nil || d.Base64 != ""
+}
+
+// IsURL reports whether d represents a file URL.
+func (d DataContent) IsURL() bool {
+	return d.variant == dataContentVariantURL || d.URL != ""
+}
+
 func (d DataContent) MarshalJSON() ([]byte, error) {
 	switch {
-	case d.Bytes != nil:
+	case d.IsData():
+		data := d.Base64
+		if d.Bytes != nil {
+			data = base64.StdEncoding.EncodeToString(d.Bytes)
+		}
 		return json.Marshal(struct {
 			Type string `json:"type"`
 			Data string `json:"data"`
-		}{Type: "data", Data: base64.StdEncoding.EncodeToString(d.Bytes)})
-	case d.Base64 != "":
-		return json.Marshal(struct {
-			Type string `json:"type"`
-			Data string `json:"data"`
-		}{Type: "data", Data: d.Base64})
-	case d.URL != "":
+		}{Type: "data", Data: data})
+	case d.IsURL():
 		return json.Marshal(struct {
 			Type string `json:"type"`
 			URL  string `json:"url"`
 		}{Type: "url", URL: d.URL})
-	case len(d.Reference) > 0:
+	case d.variant == dataContentVariantRef || len(d.Reference) > 0:
 		return json.Marshal(struct {
 			Type      string          `json:"type"`
 			Reference json.RawMessage `json:"reference"`
 		}{Type: "reference", Reference: d.Reference})
-	case d.Text != "":
+	case d.variant == dataContentVariantText || d.Text != "":
 		return json.Marshal(struct {
 			Type string `json:"type"`
 			Text string `json:"text"`
@@ -74,30 +101,62 @@ func (d DataContent) MarshalJSON() ([]byte, error) {
 // than silently decoding to an empty DataContent. See openspec change
 // provider-wire-upstream-full-compat.
 func (d *DataContent) UnmarshalJSON(data []byte) error {
-	var tagged struct {
-		Type      string          `json:"type"`
-		Data      string          `json:"data"`
-		URL       string          `json:"url"`
-		Reference json.RawMessage `json:"reference"`
-		Text      string          `json:"text"`
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
 	}
-	if err := json.Unmarshal(data, &tagged); err == nil && tagged.Type != "" {
+	if rawType, ok := fields["type"]; ok {
+		var variant dataContentVariant
+		if err := json.Unmarshal(rawType, &variant); err != nil {
+			return fmt.Errorf("provider: decoding file-data variant: %w", err)
+		}
 		*d = DataContent{}
-		switch tagged.Type {
-		case "data":
-			if tagged.Data == "" {
-				d.Bytes = []byte{}
-			} else {
-				d.Base64 = tagged.Data
+		switch variant {
+		case dataContentVariantData:
+			raw, ok := fields["data"]
+			if !ok || string(raw) == "null" {
+				return errors.New("provider: file-data variant data is required")
 			}
-		case "url":
-			d.URL = tagged.URL
-		case "reference":
-			d.Reference = tagged.Reference
-		case "text":
-			d.Text = tagged.Text
+			if err := json.Unmarshal(raw, &d.Base64); err != nil {
+				return fmt.Errorf("provider: decoding file-data data: %w", err)
+			}
+			if d.Base64 == "" {
+				d.Bytes = []byte{}
+			}
+		case dataContentVariantURL:
+			raw, ok := fields["url"]
+			if !ok || string(raw) == "null" {
+				return errors.New("provider: file-data variant url is required")
+			}
+			if err := json.Unmarshal(raw, &d.URL); err != nil {
+				return fmt.Errorf("provider: decoding file-data url: %w", err)
+			}
+			if d.URL == "" {
+				d.variant = variant
+			}
+		case dataContentVariantRef:
+			raw, ok := fields["reference"]
+			if !ok || string(raw) == "null" {
+				return errors.New("provider: file-data variant reference is required")
+			}
+			var reference map[string]string
+			if err := json.Unmarshal(raw, &reference); err != nil {
+				return fmt.Errorf("provider: decoding file-data reference: %w", err)
+			}
+			d.Reference = append(json.RawMessage(nil), raw...)
+		case dataContentVariantText:
+			raw, ok := fields["text"]
+			if !ok || string(raw) == "null" {
+				return errors.New("provider: file-data variant text is required")
+			}
+			if err := json.Unmarshal(raw, &d.Text); err != nil {
+				return fmt.Errorf("provider: decoding file-data text: %w", err)
+			}
+			if d.Text == "" {
+				d.variant = variant
+			}
 		default:
-			return fmt.Errorf("provider: unsupported file-data variant %q (supported: data, url, reference, text)", tagged.Type)
+			return fmt.Errorf("provider: unsupported file-data variant %q (supported: data, url, reference, text)", variant)
 		}
 		return nil
 	}
@@ -126,6 +185,9 @@ func (d DataContent) Validate() error {
 		n++
 	}
 	if d.Text != "" {
+		n++
+	}
+	if d.variant != "" {
 		n++
 	}
 	if n == 0 {

--- a/provider/content_test.go
+++ b/provider/content_test.go
@@ -189,6 +189,14 @@ func TestDataContentValidate_ProviderReference(t *testing.T) {
 	assert.Error(t, (DataContent{URL: "https://example.com/doc.pdf", Reference: json.RawMessage(`{}`)}).Validate())
 }
 
+func TestDataContentValidate_EmptyVariantConflict(t *testing.T) {
+	data := Base64DataContent("")
+	assert.NoError(t, data.Validate())
+
+	data.URL = "https://example.com/file"
+	assert.Error(t, data.Validate())
+}
+
 func TestContentPartType_AllConstantsCovered(t *testing.T) {
 	defined := []ContentPartType{
 		ContentPartTypeText,

--- a/provider/types.go
+++ b/provider/types.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 )
 
@@ -164,6 +165,8 @@ func (t ToolResultOutput) MarshalJSON() ([]byte, error) {
 			}
 			out["reason"] = b
 		}
+	default:
+		return nil, fmt.Errorf("provider: unsupported tool-result output type %q", t.Type)
 	}
 	if len(t.ProviderOptions) > 0 {
 		b, err := json.Marshal(t.ProviderOptions)
@@ -184,6 +187,10 @@ func (t ToolResultOutput) MarshalJSON() ([]byte, error) {
 // carrying a shape this build cannot represent), the error is returned rather
 // than silently dropping the payload.
 func (t *ToolResultOutput) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
 	var raw struct {
 		Type            ToolResultOutputType     `json:"type"`
 		Text            string                   `json:"text"`
@@ -204,10 +211,21 @@ func (t *ToolResultOutput) UnmarshalJSON(data []byte) error {
 		Reason:          raw.Reason,
 		ProviderOptions: raw.ProviderOptions,
 	}
+	if raw.Type != ToolOutputText && raw.Type != ToolOutputErrorText &&
+		raw.Type != ToolOutputJSON && raw.Type != ToolOutputErrorJSON &&
+		raw.Type != ToolOutputContent && raw.Type != ToolOutputExecutionDenied {
+		return fmt.Errorf("provider: unsupported tool-result output type %q", raw.Type)
+	}
 	// Upstream single-`value` shape: map onto the canonical split fields.
-	if len(raw.Value) != 0 && string(raw.Value) != "null" {
+	if _, ok := fields["value"]; ok {
+		if raw.Type == ToolOutputExecutionDenied {
+			return errors.New("provider: execution-denied tool result must not contain value")
+		}
 		switch raw.Type {
 		case ToolOutputText, ToolOutputErrorText:
+			if string(raw.Value) == "null" {
+				return fmt.Errorf("provider: decoding tool-result %q value: value is required", raw.Type)
+			}
 			var s string
 			if err := json.Unmarshal(raw.Value, &s); err != nil {
 				return fmt.Errorf("provider: decoding tool-result %q value as string: %w", raw.Type, err)
@@ -216,11 +234,31 @@ func (t *ToolResultOutput) UnmarshalJSON(data []byte) error {
 		case ToolOutputJSON, ToolOutputErrorJSON:
 			t.JSON = raw.Value
 		case ToolOutputContent:
+			if string(raw.Value) == "null" {
+				return errors.New("provider: decoding tool-result content value: value is required")
+			}
 			var cv []ToolResultContentValue
 			if err := json.Unmarshal(raw.Value, &cv); err != nil {
 				return fmt.Errorf("provider: decoding tool-result content value: %w", err)
 			}
 			t.Content = cv
+		}
+	} else {
+		switch raw.Type {
+		case ToolOutputText, ToolOutputErrorText:
+			rawText, ok := fields["text"]
+			if !ok || string(rawText) == "null" {
+				return fmt.Errorf("provider: decoding legacy tool-result %q: text is required", raw.Type)
+			}
+		case ToolOutputJSON, ToolOutputErrorJSON:
+			if _, ok := fields["json"]; !ok {
+				return fmt.Errorf("provider: decoding legacy tool-result %q: json is required", raw.Type)
+			}
+		case ToolOutputContent:
+			rawContent, ok := fields["content"]
+			if !ok || string(rawContent) == "null" {
+				return errors.New("provider: decoding legacy tool-result content: content is required")
+			}
 		}
 	}
 	return nil
@@ -254,33 +292,51 @@ type ToolResultContentValue struct {
 
 // MarshalJSON emits the upstream LanguageModelV4 tool-result content union.
 func (v ToolResultContentValue) MarshalJSON() ([]byte, error) {
-	type wireValue struct {
-		Type            ToolResultContentType `json:"type"`
-		Text            string                `json:"text,omitempty"`
-		Data            *DataContent          `json:"data,omitempty"`
-		MediaType       string                `json:"mediaType,omitempty"`
-		Filename        string                `json:"filename,omitempty"`
-		ProviderOptions ProviderOptions       `json:"providerOptions,omitempty"`
+	switch v.Type {
+	case ToolContentText:
+		return json.Marshal(struct {
+			Type            ToolResultContentType `json:"type"`
+			Text            string                `json:"text"`
+			ProviderOptions ProviderOptions       `json:"providerOptions,omitempty"`
+		}{Type: ToolContentText, Text: v.Text, ProviderOptions: v.ProviderOptions})
+	case ToolContentFile, ToolContentFileData, ToolContentFileURL, ToolContentFileReference:
+		if v.Data == nil {
+			return nil, errors.New("provider: tool-result file content data is required")
+		}
+		if err := v.Data.Validate(); err != nil {
+			return nil, fmt.Errorf("provider: validating tool-result file data: %w", err)
+		}
+		return json.Marshal(struct {
+			Type            ToolResultContentType `json:"type"`
+			Data            *DataContent          `json:"data"`
+			MediaType       string                `json:"mediaType"`
+			Filename        string                `json:"filename,omitempty"`
+			ProviderOptions ProviderOptions       `json:"providerOptions,omitempty"`
+		}{
+			Type:            ToolContentFile,
+			Data:            v.Data,
+			MediaType:       v.MediaType,
+			Filename:        v.Filename,
+			ProviderOptions: v.ProviderOptions,
+		})
+	case ToolContentCustom:
+		return json.Marshal(struct {
+			Type            ToolResultContentType `json:"type"`
+			ProviderOptions ProviderOptions       `json:"providerOptions,omitempty"`
+		}{Type: ToolContentCustom, ProviderOptions: v.ProviderOptions})
+	default:
+		type alias ToolResultContentValue
+		return json.Marshal(alias(v))
 	}
-
-	typeValue := v.Type
-	switch typeValue {
-	case ToolContentFileData, ToolContentFileURL, ToolContentFileReference:
-		typeValue = ToolContentFile
-	}
-	return json.Marshal(wireValue{
-		Type:            typeValue,
-		Text:            v.Text,
-		Data:            v.Data,
-		MediaType:       v.MediaType,
-		Filename:        v.Filename,
-		ProviderOptions: v.ProviderOptions,
-	})
 }
 
 // UnmarshalJSON decodes canonical LanguageModelV4 tool-result content and the
 // legacy flat file-data, file-url, and file-reference variants.
 func (v *ToolResultContentValue) UnmarshalJSON(data []byte) error {
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(data, &fields); err != nil {
+		return err
+	}
 	var raw struct {
 		Type              ToolResultContentType `json:"type"`
 		Text              string                `json:"text"`
@@ -304,35 +360,77 @@ func (v *ToolResultContentValue) UnmarshalJSON(data []byte) error {
 	}
 
 	switch raw.Type {
-	case ToolContentFile:
-		if len(raw.Data) != 0 && string(raw.Data) != "null" {
-			var fileData DataContent
-			if err := json.Unmarshal(raw.Data, &fileData); err != nil {
-				return fmt.Errorf("provider: decoding tool-result file data: %w", err)
-			}
-			v.Data = &fileData
+	case ToolContentText:
+		rawText, ok := fields["text"]
+		if !ok || string(rawText) == "null" {
+			return errors.New("provider: tool-result text content text is required")
 		}
+	case ToolContentFile:
+		rawData, ok := fields["data"]
+		if !ok || string(rawData) == "null" {
+			return errors.New("provider: tool-result file content data is required")
+		}
+		rawMediaType, ok := fields["mediaType"]
+		if !ok || string(rawMediaType) == "null" {
+			return errors.New("provider: tool-result file content mediaType is required")
+		}
+		var dataFields map[string]json.RawMessage
+		if err := json.Unmarshal(rawData, &dataFields); err != nil {
+			return fmt.Errorf("provider: decoding tool-result file data: %w", err)
+		}
+		if _, ok := dataFields["type"]; !ok {
+			return errors.New("provider: tool-result file data type is required")
+		}
+		var fileData DataContent
+		if err := json.Unmarshal(raw.Data, &fileData); err != nil {
+			return fmt.Errorf("provider: decoding tool-result file data: %w", err)
+		}
+		if err := fileData.Validate(); err != nil {
+			return fmt.Errorf("provider: validating tool-result file data: %w", err)
+		}
+		v.Data = &fileData
 	case ToolContentFileData:
+		rawData, ok := fields["data"]
+		if !ok || string(rawData) == "null" {
+			return errors.New("provider: legacy tool-result file data is required")
+		}
+		rawMediaType, ok := fields["mediaType"]
+		if !ok || string(rawMediaType) == "null" {
+			return errors.New("provider: legacy tool-result file mediaType is required")
+		}
 		var base64Data string
-		if len(raw.Data) != 0 && string(raw.Data) != "null" {
-			if err := json.Unmarshal(raw.Data, &base64Data); err != nil {
-				return fmt.Errorf("provider: decoding legacy tool-result file data: %w", err)
-			}
+		if err := json.Unmarshal(raw.Data, &base64Data); err != nil {
+			return fmt.Errorf("provider: decoding legacy tool-result file data: %w", err)
 		}
 		v.Type = ToolContentFile
 		v.Data = &DataContent{Base64: base64Data}
+		if base64Data == "" {
+			v.Data.variant = dataContentVariantData
+		}
 	case ToolContentFileURL:
+		rawURL, ok := fields["url"]
+		if !ok || string(rawURL) == "null" {
+			return errors.New("provider: legacy tool-result file URL is required")
+		}
 		v.Type = ToolContentFile
 		v.Data = &DataContent{URL: raw.URL}
-	case ToolContentFileReference:
-		v.Type = ToolContentFile
-		if raw.ProviderReference != nil {
-			reference, err := json.Marshal(raw.ProviderReference)
-			if err != nil {
-				return fmt.Errorf("provider: encoding legacy tool-result file reference: %w", err)
-			}
-			v.Data = &DataContent{Reference: reference}
+		if raw.URL == "" {
+			v.Data.variant = dataContentVariantURL
 		}
+	case ToolContentFileReference:
+		rawReference, ok := fields["providerReference"]
+		if !ok || string(rawReference) == "null" {
+			return errors.New("provider: legacy tool-result providerReference is required")
+		}
+		reference, err := json.Marshal(raw.ProviderReference)
+		if err != nil {
+			return fmt.Errorf("provider: encoding legacy tool-result file reference: %w", err)
+		}
+		v.Type = ToolContentFile
+		v.Data = &DataContent{Reference: reference}
+	case ToolContentCustom:
+	default:
+		return fmt.Errorf("provider: unsupported tool-result content type %q", raw.Type)
 	}
 	return nil
 }

--- a/provider/types.go
+++ b/provider/types.go
@@ -111,9 +111,9 @@ const (
 )
 
 // ToolResultOutput carries the output of a tool execution. The Type field
-// determines which value fields are populated. The Go shape intentionally uses
-// split Text/JSON/Content/Reason fields instead of upstream's single `value`
-// field; see the lossless-provider-wire design rationale for D8.
+// determines which value fields are populated. The Go representation uses
+// split Text/JSON/Content/Reason fields while its JSON codec emits and accepts
+// upstream's single `value` union.
 type ToolResultOutput struct {
 	Type            ToolResultOutputType     `json:"type"`
 	Text            string                   `json:"text,omitempty"`
@@ -175,13 +175,9 @@ func (t ToolResultOutput) MarshalJSON() ([]byte, error) {
 	return json.Marshal(out)
 }
 
-// UnmarshalJSON decodes a [ToolResultOutput] from the canonical Go-to-Go wire
-// form (split `text`/`json`/`content`/`reason` fields) and additionally
-// tolerates the upstream Vercel AI SDK LanguageModelV4 single-`value` shape
-// (`{"type":"text","value":...}`, `{"type":"json","value":...}`, etc.), mapping
-// `value` onto the corresponding canonical field. This is decode-only
-// tolerance; marshaling continues to emit the split form. See openspec change
-// provider-wire-upstream-decode-compat.
+// UnmarshalJSON decodes a [ToolResultOutput] from the upstream Vercel AI SDK
+// LanguageModelV4 single-`value` shape and additionally tolerates the legacy
+// Go-to-Go split `text`/`json`/`content`/`reason` fields.
 //
 // Decoding fails closed: if an upstream `value` cannot be mapped onto the
 // canonical field for its type (e.g. a malformed value, or a `content` value
@@ -234,21 +230,109 @@ func (t *ToolResultOutput) UnmarshalJSON(data []byte) error {
 type ToolResultContentType string
 
 const (
-	ToolContentText          ToolResultContentType = "text"
+	ToolContentText   ToolResultContentType = "text"
+	ToolContentFile   ToolResultContentType = "file"
+	ToolContentCustom ToolResultContentType = "custom"
+
 	ToolContentFileData      ToolResultContentType = "file-data"
 	ToolContentFileURL       ToolResultContentType = "file-url"
 	ToolContentFileReference ToolResultContentType = "file-reference"
-	ToolContentCustom        ToolResultContentType = "custom"
 )
 
 // ToolResultContentValue is a single piece of multimodal tool result content.
+// File content uses [DataContent], matching the LanguageModelV4 tagged data
+// union. The legacy file-data, file-url, and file-reference discriminators are
+// accepted during decoding and normalized to [ToolContentFile].
 type ToolResultContentValue struct {
-	Type              ToolResultContentType `json:"type"`
-	Text              string                `json:"text,omitempty"`
-	Data              string                `json:"data,omitempty"`
-	MediaType         string                `json:"mediaType,omitempty"`
-	Filename          string                `json:"filename,omitempty"`
-	URL               string                `json:"url,omitempty"`
-	ProviderReference map[string]string     `json:"providerReference,omitempty"`
-	ProviderOptions   ProviderOptions       `json:"providerOptions,omitempty"`
+	Type            ToolResultContentType `json:"type"`
+	Text            string                `json:"text,omitempty"`
+	Data            *DataContent          `json:"data,omitempty"`
+	MediaType       string                `json:"mediaType,omitempty"`
+	Filename        string                `json:"filename,omitempty"`
+	ProviderOptions ProviderOptions       `json:"providerOptions,omitempty"`
+}
+
+// MarshalJSON emits the upstream LanguageModelV4 tool-result content union.
+func (v ToolResultContentValue) MarshalJSON() ([]byte, error) {
+	type wireValue struct {
+		Type            ToolResultContentType `json:"type"`
+		Text            string                `json:"text,omitempty"`
+		Data            *DataContent          `json:"data,omitempty"`
+		MediaType       string                `json:"mediaType,omitempty"`
+		Filename        string                `json:"filename,omitempty"`
+		ProviderOptions ProviderOptions       `json:"providerOptions,omitempty"`
+	}
+
+	typeValue := v.Type
+	switch typeValue {
+	case ToolContentFileData, ToolContentFileURL, ToolContentFileReference:
+		typeValue = ToolContentFile
+	}
+	return json.Marshal(wireValue{
+		Type:            typeValue,
+		Text:            v.Text,
+		Data:            v.Data,
+		MediaType:       v.MediaType,
+		Filename:        v.Filename,
+		ProviderOptions: v.ProviderOptions,
+	})
+}
+
+// UnmarshalJSON decodes canonical LanguageModelV4 tool-result content and the
+// legacy flat file-data, file-url, and file-reference variants.
+func (v *ToolResultContentValue) UnmarshalJSON(data []byte) error {
+	var raw struct {
+		Type              ToolResultContentType `json:"type"`
+		Text              string                `json:"text"`
+		Data              json.RawMessage       `json:"data"`
+		MediaType         string                `json:"mediaType"`
+		Filename          string                `json:"filename"`
+		URL               string                `json:"url"`
+		ProviderReference map[string]string     `json:"providerReference"`
+		ProviderOptions   ProviderOptions       `json:"providerOptions"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	*v = ToolResultContentValue{
+		Type:            raw.Type,
+		Text:            raw.Text,
+		MediaType:       raw.MediaType,
+		Filename:        raw.Filename,
+		ProviderOptions: raw.ProviderOptions,
+	}
+
+	switch raw.Type {
+	case ToolContentFile:
+		if len(raw.Data) != 0 && string(raw.Data) != "null" {
+			var fileData DataContent
+			if err := json.Unmarshal(raw.Data, &fileData); err != nil {
+				return fmt.Errorf("provider: decoding tool-result file data: %w", err)
+			}
+			v.Data = &fileData
+		}
+	case ToolContentFileData:
+		var base64Data string
+		if len(raw.Data) != 0 && string(raw.Data) != "null" {
+			if err := json.Unmarshal(raw.Data, &base64Data); err != nil {
+				return fmt.Errorf("provider: decoding legacy tool-result file data: %w", err)
+			}
+		}
+		v.Type = ToolContentFile
+		v.Data = &DataContent{Base64: base64Data}
+	case ToolContentFileURL:
+		v.Type = ToolContentFile
+		v.Data = &DataContent{URL: raw.URL}
+	case ToolContentFileReference:
+		v.Type = ToolContentFile
+		if raw.ProviderReference != nil {
+			reference, err := json.Marshal(raw.ProviderReference)
+			if err != nil {
+				return fmt.Errorf("provider: encoding legacy tool-result file reference: %w", err)
+			}
+			v.Data = &DataContent{Reference: reference}
+		}
+	}
+	return nil
 }

--- a/provider/types.go
+++ b/provider/types.go
@@ -403,10 +403,8 @@ func (v *ToolResultContentValue) UnmarshalJSON(data []byte) error {
 			return fmt.Errorf("provider: decoding legacy tool-result file data: %w", err)
 		}
 		v.Type = ToolContentFile
-		v.Data = &DataContent{Base64: base64Data}
-		if base64Data == "" {
-			v.Data.variant = dataContentVariantData
-		}
+		fileData := Base64DataContent(base64Data)
+		v.Data = &fileData
 	case ToolContentFileURL:
 		rawURL, ok := fields["url"]
 		if !ok || string(rawURL) == "null" {

--- a/provider/types_test.go
+++ b/provider/types_test.go
@@ -88,6 +88,11 @@ func TestToolResultContentValue_RoundTrip(t *testing.T) {
 		want string
 	}{
 		{
+			name: "empty text",
+			val:  ToolResultContentValue{Type: ToolContentText},
+			want: `{"type":"text","text":""}`,
+		},
+		{
 			name: "file data",
 			val:  ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{Base64: "base64data"}, MediaType: "application/pdf", Filename: "report.pdf"},
 			want: `{"type":"file","data":{"type":"data","data":"base64data"},"mediaType":"application/pdf","filename":"report.pdf"}`,
@@ -126,6 +131,35 @@ func TestToolResultContentValue_RoundTrip(t *testing.T) {
 	}
 }
 
+func TestToolResultContentValue_MarshalRejectsInvalidFileData(t *testing.T) {
+	tests := []struct {
+		name string
+		data *DataContent
+	}{
+		{name: "missing", data: nil},
+		{name: "empty", data: &DataContent{}},
+		{name: "multiple sources", data: &DataContent{Base64: "aGk=", URL: "https://example.com/file"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := json.Marshal(ToolResultContentValue{Type: ToolContentFile, Data: tc.data, MediaType: "image/png"})
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestToolResultContentValue_MarshalOmitsInactiveVariantFields(t *testing.T) {
+	data, err := json.Marshal(ToolResultContentValue{
+		Type:      ToolContentCustom,
+		Text:      "not custom content",
+		Data:      &DataContent{Base64: "ignored"},
+		MediaType: "image/png",
+		Filename:  "ignored.png",
+	})
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"type":"custom"}`, string(data))
+}
+
 func TestToolResultOutput(t *testing.T) {
 	t.Run("text variant has zero-valued non-text fields", func(t *testing.T) {
 		out := ToolResultOutput{Type: ToolOutputText, Text: "result data"}
@@ -139,6 +173,11 @@ func TestToolResultOutput(t *testing.T) {
 		assert.Empty(t, out.Text)
 		assert.Nil(t, out.Content)
 		assert.Empty(t, out.Reason)
+	})
+
+	t.Run("unknown variant cannot marshal", func(t *testing.T) {
+		_, err := json.Marshal(ToolResultOutput{Type: ToolResultOutputType("future")})
+		require.Error(t, err)
 	})
 }
 

--- a/provider/types_test.go
+++ b/provider/types_test.go
@@ -81,56 +81,49 @@ func TestUsageJSONSerialization(t *testing.T) {
 	assert.Nil(t, decoded.InputTokens.CacheWrite)
 }
 
-func TestToolResultContentValue_ExpandedTypes(t *testing.T) {
+func TestToolResultContentValue_RoundTrip(t *testing.T) {
 	tests := []struct {
 		name string
 		val  ToolResultContentValue
-		key  ToolResultContentType
+		want string
 	}{
 		{
-			name: "file-data",
-			val:  ToolResultContentValue{Type: ToolContentFileData, Data: "base64data", MediaType: "application/pdf", Filename: "report.pdf"},
-			key:  ToolContentFileData,
+			name: "file data",
+			val:  ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{Base64: "base64data"}, MediaType: "application/pdf", Filename: "report.pdf"},
+			want: `{"type":"file","data":{"type":"data","data":"base64data"},"mediaType":"application/pdf","filename":"report.pdf"}`,
 		},
 		{
-			name: "file-url",
-			val:  ToolResultContentValue{Type: ToolContentFileURL, URL: "https://example.com/file.pdf"},
-			key:  ToolContentFileURL,
+			name: "file URL",
+			val:  ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{URL: "https://example.com/file.pdf"}, MediaType: "application/pdf"},
+			want: `{"type":"file","data":{"type":"url","url":"https://example.com/file.pdf"},"mediaType":"application/pdf"}`,
 		},
 		{
-			name: "file-reference",
-			val:  ToolResultContentValue{Type: ToolContentFileReference, ProviderReference: map[string]string{"openai": "file-abc123"}},
-			key:  ToolContentFileReference,
+			name: "file reference",
+			val:  ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{Reference: json.RawMessage(`{"openai":"file-abc123"}`)}, MediaType: "application/pdf"},
+			want: `{"type":"file","data":{"type":"reference","reference":{"openai":"file-abc123"}},"mediaType":"application/pdf"}`,
 		},
 		{
-			name: "file-data with image mediaType",
-			val:  ToolResultContentValue{Type: ToolContentFileData, Data: "base64img", MediaType: "image/png"},
-			key:  ToolContentFileData,
+			name: "file text",
+			val:  ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{Text: "document"}, MediaType: "text/plain"},
+			want: `{"type":"file","data":{"type":"text","text":"document"},"mediaType":"text/plain"}`,
 		},
 		{
 			name: "custom",
 			val:  ToolResultContentValue{Type: ToolContentCustom},
-			key:  ToolContentCustom,
+			want: `{"type":"custom"}`,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.key, tc.val.Type)
 			data, err := json.Marshal(tc.val)
 			require.NoError(t, err)
+			assert.JSONEq(t, tc.want, string(data))
+
 			var decoded ToolResultContentValue
 			require.NoError(t, json.Unmarshal(data, &decoded))
-			assert.Equal(t, tc.val.Type, decoded.Type)
+			assert.Equal(t, tc.val, decoded)
 		})
 	}
-
-	t.Run("file-reference serialization", func(t *testing.T) {
-		val := ToolResultContentValue{Type: ToolContentFileReference, ProviderReference: map[string]string{"openai": "file-abc123"}}
-		data, err := json.Marshal(val)
-		require.NoError(t, err)
-		assert.Contains(t, string(data), `"providerReference"`)
-		assert.Contains(t, string(data), `"openai"`)
-	})
 }
 
 func TestToolResultOutput(t *testing.T) {

--- a/provider/upstream_decode_compat_test.go
+++ b/provider/upstream_decode_compat_test.go
@@ -173,7 +173,7 @@ func TestToolResultContentValue_UnmarshalLegacyFileVariants(t *testing.T) {
 		{
 			name:    "empty raw base64",
 			in:      `{"type":"file-data","data":"","mediaType":"image/png"}`,
-			want:    ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{variant: dataContentVariantData}, MediaType: "image/png"},
+			want:    ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{Bytes: []byte{}}, MediaType: "image/png"},
 			encoded: `{"type":"file","data":{"type":"data","data":""},"mediaType":"image/png"}`,
 		},
 		{

--- a/provider/upstream_decode_compat_test.go
+++ b/provider/upstream_decode_compat_test.go
@@ -151,6 +151,46 @@ func TestStreamFileData_UnmarshalRejectsUnsupportedVariants(t *testing.T) {
 	}
 }
 
+func TestToolResultContentValue_UnmarshalLegacyFileVariants(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want ToolResultContentValue
+	}{
+		{
+			name: "raw base64",
+			in:   `{"type":"file-data","data":"aGk=","mediaType":"image/png"}`,
+			want: ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{Base64: "aGk="}, MediaType: "image/png"},
+		},
+		{
+			name: "empty raw base64",
+			in:   `{"type":"file-data","data":"","mediaType":"image/png"}`,
+			want: ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{}, MediaType: "image/png"},
+		},
+		{
+			name: "URL",
+			in:   `{"type":"file-url","url":"https://example.com/file.pdf","mediaType":"application/pdf"}`,
+			want: ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{URL: "https://example.com/file.pdf"}, MediaType: "application/pdf"},
+		},
+		{
+			name: "provider reference",
+			in:   `{"type":"file-reference","providerReference":{"openai":"file-123"},"mediaType":"application/pdf"}`,
+			want: ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{Reference: json.RawMessage(`{"openai":"file-123"}`)}, MediaType: "application/pdf"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var value ToolResultContentValue
+			require.NoError(t, json.Unmarshal([]byte(tc.in), &value))
+			assert.Equal(t, tc.want, value)
+
+			encoded, err := json.Marshal(value)
+			require.NoError(t, err)
+			assert.Contains(t, string(encoded), `"type":"file"`)
+		})
+	}
+}
+
 // TestDataContent_UnmarshalUnknownVariantFailsClosed locks the fail-closed
 // policy: an unknown tagged file-data variant is rejected with a decode error,
 // not silently turned into an empty DataContent. Supported variants

--- a/provider/upstream_decode_compat_test.go
+++ b/provider/upstream_decode_compat_test.go
@@ -79,13 +79,19 @@ func TestDataContent_UnmarshalUpstreamUnion(t *testing.T) {
 	}{
 		{"url", `{"type":"url","url":"https://example.com/x.png"}`, DataContent{URL: "https://example.com/x.png"}},
 		{"data-base64", `{"type":"data","data":"aGVsbG8="}`, DataContent{Base64: "aGVsbG8="}},
-		{"empty-data", `{"type":"data","data":""}`, DataContent{Bytes: []byte{}}},
+		{"empty data", `{"type":"data","data":""}`, DataContent{Bytes: []byte{}}},
+		{"empty URL", `{"type":"url","url":""}`, DataContent{variant: dataContentVariantURL}},
+		{"empty text", `{"type":"text","text":""}`, DataContent{variant: dataContentVariantText}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			var d DataContent
 			require.NoError(t, json.Unmarshal([]byte(tc.in), &d))
 			assert.Equal(t, tc.want, d)
+
+			encoded, err := json.Marshal(d)
+			require.NoError(t, err)
+			assert.JSONEq(t, tc.in, string(encoded))
 		})
 	}
 }
@@ -153,29 +159,34 @@ func TestStreamFileData_UnmarshalRejectsUnsupportedVariants(t *testing.T) {
 
 func TestToolResultContentValue_UnmarshalLegacyFileVariants(t *testing.T) {
 	cases := []struct {
-		name string
-		in   string
-		want ToolResultContentValue
+		name    string
+		in      string
+		want    ToolResultContentValue
+		encoded string
 	}{
 		{
-			name: "raw base64",
-			in:   `{"type":"file-data","data":"aGk=","mediaType":"image/png"}`,
-			want: ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{Base64: "aGk="}, MediaType: "image/png"},
+			name:    "raw base64",
+			in:      `{"type":"file-data","data":"aGk=","mediaType":"image/png"}`,
+			want:    ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{Base64: "aGk="}, MediaType: "image/png"},
+			encoded: `{"type":"file","data":{"type":"data","data":"aGk="},"mediaType":"image/png"}`,
 		},
 		{
-			name: "empty raw base64",
-			in:   `{"type":"file-data","data":"","mediaType":"image/png"}`,
-			want: ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{}, MediaType: "image/png"},
+			name:    "empty raw base64",
+			in:      `{"type":"file-data","data":"","mediaType":"image/png"}`,
+			want:    ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{variant: dataContentVariantData}, MediaType: "image/png"},
+			encoded: `{"type":"file","data":{"type":"data","data":""},"mediaType":"image/png"}`,
 		},
 		{
-			name: "URL",
-			in:   `{"type":"file-url","url":"https://example.com/file.pdf","mediaType":"application/pdf"}`,
-			want: ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{URL: "https://example.com/file.pdf"}, MediaType: "application/pdf"},
+			name:    "URL",
+			in:      `{"type":"file-url","url":"https://example.com/file.pdf","mediaType":"application/pdf"}`,
+			want:    ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{URL: "https://example.com/file.pdf"}, MediaType: "application/pdf"},
+			encoded: `{"type":"file","data":{"type":"url","url":"https://example.com/file.pdf"},"mediaType":"application/pdf"}`,
 		},
 		{
-			name: "provider reference",
-			in:   `{"type":"file-reference","providerReference":{"openai":"file-123"},"mediaType":"application/pdf"}`,
-			want: ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{Reference: json.RawMessage(`{"openai":"file-123"}`)}, MediaType: "application/pdf"},
+			name:    "provider reference",
+			in:      `{"type":"file-reference","providerReference":{"openai":"file-123"},"mediaType":"application/pdf"}`,
+			want:    ToolResultContentValue{Type: ToolContentFile, Data: &DataContent{Reference: json.RawMessage(`{"openai":"file-123"}`)}, MediaType: "application/pdf"},
+			encoded: `{"type":"file","data":{"type":"reference","reference":{"openai":"file-123"}},"mediaType":"application/pdf"}`,
 		},
 	}
 	for _, tc := range cases {
@@ -186,7 +197,7 @@ func TestToolResultContentValue_UnmarshalLegacyFileVariants(t *testing.T) {
 
 			encoded, err := json.Marshal(value)
 			require.NoError(t, err)
-			assert.Contains(t, string(encoded), `"type":"file"`)
+			assert.JSONEq(t, tc.encoded, string(encoded))
 		})
 	}
 }
@@ -203,6 +214,28 @@ func TestDataContent_UnmarshalUnknownVariantFailsClosed(t *testing.T) {
 	assert.Contains(t, err.Error(), "unsupported file-data variant")
 }
 
+func TestDataContent_UnmarshalMalformedTaggedVariantFailsClosed(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+	}{
+		{"data has wrong type", `{"type":"data","data":{"oops":true}}`},
+		{"data is missing", `{"type":"data"}`},
+		{"URL has wrong type", `{"type":"url","url":42}`},
+		{"URL is null", `{"type":"url","url":null}`},
+		{"reference has wrong type", `{"type":"reference","reference":"file-1"}`},
+		{"reference value has wrong type", `{"type":"reference","reference":{"openai":42}}`},
+		{"text has wrong type", `{"type":"text","text":[]}`},
+		{"text is missing", `{"type":"text"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var d DataContent
+			require.Error(t, json.Unmarshal([]byte(tc.in), &d))
+		})
+	}
+}
+
 // TestToolResultOutput_UnmarshalMalformedValueFailsClosed locks the fail-closed
 // policy: an upstream `value` that cannot be mapped onto the canonical field
 // for its type returns a decode error instead of silently dropping the payload.
@@ -211,14 +244,46 @@ func TestToolResultOutput_UnmarshalMalformedValueFailsClosed(t *testing.T) {
 		name string
 		in   string
 	}{
+		{"text value is missing", `{"type":"text"}`},
 		{"text value is not a string", `{"type":"text","value":123}`},
+		{"text value is null", `{"type":"text","value":null}`},
+		{"legacy text is missing", `{"type":"text","providerOptions":{}}`},
+		{"json value is missing", `{"type":"json"}`},
+		{"content value is missing", `{"type":"content"}`},
+		{"unknown output type", `{"type":"future","value":"x"}`},
+		{"execution denied has value", `{"type":"execution-denied","value":"no"}`},
 		{"content value is not an array", `{"type":"content","value":"nope"}`},
+		{"content value is null", `{"type":"content","value":null}`},
+		{"content item is null", `{"type":"content","value":[null]}`},
+		{"content item type is missing", `{"type":"content","value":[{}]}`},
+		{"content item type is unknown", `{"type":"content","value":[{"type":"future"}]}`},
 		{
-			// Upstream content file item carries a nested file-data union that
-			// the canonical ToolResultContentValue (flat Data string) cannot
-			// represent; it must error, not decode to empty content.
-			name: "content value with nested file-data union",
-			in:   `{"type":"content","value":[{"type":"file","data":{"type":"data","data":"aGk="},"mediaType":"image/png"}]}`,
+			name: "content file has unknown data variant",
+			in:   `{"type":"content","value":[{"type":"file","data":{"type":"future","data":"aGk="},"mediaType":"image/png"}]}`,
+		},
+		{
+			name: "content file has malformed data variant",
+			in:   `{"type":"content","value":[{"type":"file","data":{"type":"data","data":{"oops":true}},"mediaType":"image/png"}]}`,
+		},
+		{
+			name: "content file data is missing",
+			in:   `{"type":"content","value":[{"type":"file","mediaType":"image/png"}]}`,
+		},
+		{
+			name: "content file data type is missing",
+			in:   `{"type":"content","value":[{"type":"file","data":{},"mediaType":"image/png"}]}`,
+		},
+		{
+			name: "content file mediaType is missing",
+			in:   `{"type":"content","value":[{"type":"file","data":{"type":"data","data":"aGk="}}]}`,
+		},
+		{
+			name: "content text value is missing text",
+			in:   `{"type":"content","value":[{"type":"text"}]}`,
+		},
+		{
+			name: "legacy content file data is not a string",
+			in:   `{"type":"content","value":[{"type":"file-data","data":{"type":"data","data":"aGk="},"mediaType":"image/png"}]}`,
 		},
 	}
 	for _, tc := range cases {

--- a/providers/anthropic/convert_request.go
+++ b/providers/anthropic/convert_request.go
@@ -1859,13 +1859,20 @@ func serializeToolOutput(output *provider.ToolResultOutput, warnings *[]provider
 				blocks = append(blocks, anthropic.BetaToolResultBlockParamContentUnion{
 					OfText: &anthropic.BetaTextBlockParam{Text: v.Text},
 				})
-			case provider.ToolContentFileData:
-				if v.Data != "" && strings.HasPrefix(v.MediaType, "image/") {
+			case provider.ToolContentFile:
+				if v.Data == nil || !strings.HasPrefix(v.MediaType, "image/") {
+					continue
+				}
+				data := v.Data.Base64
+				if data == "" && len(v.Data.Bytes) > 0 {
+					data = base64.StdEncoding.EncodeToString(v.Data.Bytes)
+				}
+				if data != "" {
 					blocks = append(blocks, anthropic.BetaToolResultBlockParamContentUnion{
 						OfImage: &anthropic.BetaImageBlockParam{
 							Source: anthropic.BetaImageBlockParamSourceUnion{
 								OfBase64: &anthropic.BetaBase64ImageSourceParam{
-									Data:      v.Data,
+									Data:      data,
 									MediaType: anthropic.BetaBase64ImageSourceMediaType(v.MediaType),
 								},
 							},

--- a/providers/anthropic/convert_request.go
+++ b/providers/anthropic/convert_request.go
@@ -1867,7 +1867,7 @@ func serializeToolOutput(output *provider.ToolResultOutput, warnings *[]provider
 				if data == "" && len(v.Data.Bytes) > 0 {
 					data = base64.StdEncoding.EncodeToString(v.Data.Bytes)
 				}
-				if data != "" {
+				if v.Data.IsData() {
 					blocks = append(blocks, anthropic.BetaToolResultBlockParamContentUnion{
 						OfImage: &anthropic.BetaImageBlockParam{
 							Source: anthropic.BetaImageBlockParamSourceUnion{

--- a/providers/anthropic/convert_request_test.go
+++ b/providers/anthropic/convert_request_test.go
@@ -1534,7 +1534,7 @@ func TestSerializeToolOutput_Content(t *testing.T) {
 		Type: provider.ToolOutputContent,
 		Content: []provider.ToolResultContentValue{
 			{Type: provider.ToolContentText, Text: "result text"},
-			{Type: provider.ToolContentFileData, Data: "imgdata", MediaType: "image/png"},
+			{Type: provider.ToolContentFile, Data: &provider.DataContent{Base64: "imgdata"}, MediaType: "image/png"},
 		},
 	}
 

--- a/providers/anthropic/convert_request_test.go
+++ b/providers/anthropic/convert_request_test.go
@@ -630,6 +630,30 @@ func TestBuildParams_ToolMessage(t *testing.T) {
 	assert.Equal(t, "call_1", p.Messages[0].Content[0].OfToolResult.ToolUseID)
 }
 
+func TestBuildParams_ToolMessage_EmptyFileData(t *testing.T) {
+	data := provider.Base64DataContent("")
+	opts := provider.CallOptions{
+		Prompt: []provider.Message{
+			provider.NewToolMessage(provider.ToolResultPart("call_1", "search", &provider.ToolResultOutput{
+				Type: provider.ToolOutputContent,
+				Content: []provider.ToolResultContentValue{
+					{Type: provider.ToolContentFile, Data: &data, MediaType: "image/png"},
+				},
+			})),
+		},
+	}
+
+	p, _, _, _, err := buildParams("claude-sonnet-4-6", opts, false)
+	require.NoError(t, err)
+
+	result := p.Messages[0].Content[0].OfToolResult
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+	require.NotNil(t, result.Content[0].OfImage)
+	require.NotNil(t, result.Content[0].OfImage.Source.OfBase64)
+	assert.Empty(t, result.Content[0].OfImage.Source.OfBase64.Data)
+}
+
 func TestBuildParams_Tools(t *testing.T) {
 	opts := provider.CallOptions{
 		Tools: []provider.Tool{

--- a/providers/bedrock/convert_messages.go
+++ b/providers/bedrock/convert_messages.go
@@ -639,6 +639,33 @@ func buildToolResult(p provider.ContentPart, documentCounter *int, isMistral boo
 					})
 					continue
 				}
+				if c.Data.IsURL() {
+					url := c.Data.URL
+					if !isS3URL(url) {
+						*warnings = append(*warnings, provider.Warning{
+							Type:    provider.WarnUnsupported,
+							Feature: "toolResultFileURL",
+							Details: fmt.Sprintf("Bedrock tool results only accept S3 image or video URLs; got %q with media type %q", url, c.MediaType),
+						})
+						continue
+					}
+					if format, ok := imageMediaTypeFormat[c.MediaType]; ok {
+						out.Content = append(out.Content, toolResultContent{
+							Image: &imageBlock{Format: format, Source: imageSource{S3Location: &s3LocationBlock{URI: url}}},
+						})
+					} else if format, ok := videoMediaTypeFormat[c.MediaType]; ok {
+						out.Content = append(out.Content, toolResultContent{
+							Video: &videoBlock{Format: format, Source: videoSource{S3Location: &s3LocationBlock{URI: url}}},
+						})
+					} else {
+						*warnings = append(*warnings, provider.Warning{
+							Type:    provider.WarnUnsupported,
+							Feature: "toolResultFileURL",
+							Details: fmt.Sprintf("Bedrock tool results only accept supported image or video media types; got %q", c.MediaType),
+						})
+					}
+					continue
+				}
 				base64Data := c.Data.Base64
 				if base64Data == "" && len(c.Data.Bytes) > 0 {
 					base64Data = base64.StdEncoding.EncodeToString(c.Data.Bytes)
@@ -677,7 +704,7 @@ func buildToolResult(p provider.ContentPart, documentCounter *int, isMistral boo
 						return nil, fmt.Errorf("bedrock: video media type %q is not supported", mediaType)
 					}
 					out.Content = append(out.Content, toolResultContent{
-						Video: &videoBlock{Format: format, Source: videoSource{Bytes: c.Data}},
+						Video: &videoBlock{Format: format, Source: videoSource{Bytes: base64Data}},
 					})
 					continue
 				}
@@ -686,30 +713,6 @@ func buildToolResult(p provider.ContentPart, documentCounter *int, isMistral boo
 					return nil, err
 				}
 				out.Content = append(out.Content, toolResultContent{Document: document})
-			case provider.ToolContentFileURL:
-				if !isS3URL(c.URL) {
-					*warnings = append(*warnings, provider.Warning{
-						Type:    provider.WarnUnsupported,
-						Feature: "toolResultFileURL",
-						Details: fmt.Sprintf("Bedrock tool results only accept S3 image or video URLs; got %q with media type %q", c.URL, c.MediaType),
-					})
-					continue
-				}
-				if format, ok := imageMediaTypeFormat[c.MediaType]; ok {
-					out.Content = append(out.Content, toolResultContent{
-						Image: &imageBlock{Format: format, Source: imageSource{S3Location: &s3LocationBlock{URI: c.URL}}},
-					})
-				} else if format, ok := videoMediaTypeFormat[c.MediaType]; ok {
-					out.Content = append(out.Content, toolResultContent{
-						Video: &videoBlock{Format: format, Source: videoSource{S3Location: &s3LocationBlock{URI: c.URL}}},
-					})
-				} else {
-					*warnings = append(*warnings, provider.Warning{
-						Type:    provider.WarnUnsupported,
-						Feature: "toolResultFileURL",
-						Details: fmt.Sprintf("Bedrock tool results only accept supported image or video media types; got %q", c.MediaType),
-					})
-				}
 			default:
 				*warnings = append(*warnings, provider.Warning{
 					Type:    provider.WarnUnsupported,

--- a/providers/bedrock/convert_messages.go
+++ b/providers/bedrock/convert_messages.go
@@ -630,11 +630,31 @@ func buildToolResult(p provider.ContentPart, documentCounter *int, isMistral boo
 			switch c.Type {
 			case provider.ToolContentText:
 				out.Content = append(out.Content, toolResultContent{Text: c.Text})
-			case provider.ToolContentFileData:
+			case provider.ToolContentFile:
+				if c.Data == nil {
+					*warnings = append(*warnings, provider.Warning{
+						Type:    provider.WarnUnsupported,
+						Feature: "toolResultContentPart",
+						Details: "Bedrock tool result file has no data",
+					})
+					continue
+				}
+				base64Data := c.Data.Base64
+				if base64Data == "" && len(c.Data.Bytes) > 0 {
+					base64Data = base64.StdEncoding.EncodeToString(c.Data.Bytes)
+				}
+				if base64Data == "" {
+					*warnings = append(*warnings, provider.Warning{
+						Type:    provider.WarnUnsupported,
+						Feature: "toolResultContentPart",
+						Details: "Bedrock tool result files support only inline data",
+					})
+					continue
+				}
 				filePart := provider.ContentPart{
 					MediaType:       c.MediaType,
 					Filename:        c.Filename,
-					Data:            &provider.DataContent{Base64: c.Data},
+					Data:            c.Data,
 					ProviderOptions: c.ProviderOptions,
 				}
 				mediaType, err := resolveFullMediaType(filePart)
@@ -648,7 +668,7 @@ func buildToolResult(p provider.ContentPart, documentCounter *int, isMistral boo
 						return nil, fmt.Errorf("bedrock: image media type %q is not supported", mediaType)
 					}
 					out.Content = append(out.Content, toolResultContent{
-						Image: &imageBlock{Format: format, Source: imageSource{Bytes: c.Data}},
+						Image: &imageBlock{Format: format, Source: imageSource{Bytes: base64Data}},
 					})
 					continue
 				case "video":
@@ -661,7 +681,7 @@ func buildToolResult(p provider.ContentPart, documentCounter *int, isMistral boo
 					})
 					continue
 				}
-				document, err := buildDocumentBlock(mediaType, c.Filename, c.Data, c.ProviderOptions, documentCounter)
+				document, err := buildDocumentBlock(mediaType, c.Filename, base64Data, c.ProviderOptions, documentCounter)
 				if err != nil {
 					return nil, err
 				}

--- a/providers/bedrock/convert_messages.go
+++ b/providers/bedrock/convert_messages.go
@@ -643,7 +643,7 @@ func buildToolResult(p provider.ContentPart, documentCounter *int, isMistral boo
 				if base64Data == "" && len(c.Data.Bytes) > 0 {
 					base64Data = base64.StdEncoding.EncodeToString(c.Data.Bytes)
 				}
-				if base64Data == "" {
+				if !c.Data.IsData() {
 					*warnings = append(*warnings, provider.Warning{
 						Type:    provider.WarnUnsupported,
 						Feature: "toolResultContentPart",

--- a/providers/bedrock/convert_request_test.go
+++ b/providers/bedrock/convert_request_test.go
@@ -1021,8 +1021,8 @@ func TestBuildRequest_VideoMessage(t *testing.T) {
 func TestBuildRequest_ToolResultVideo(t *testing.T) {
 	t.Run("inline", func(t *testing.T) {
 		req, warnings, _ := mustBuildRequest(t, testAnthropicModel, toolResultFileCallOptions(provider.ToolResultContentValue{
-			Type:      provider.ToolContentFileData,
-			Data:      "AAECAw==",
+			Type:      provider.ToolContentFile,
+			Data:      &provider.DataContent{Base64: "AAECAw=="},
 			MediaType: "video/mp4",
 		}))
 		result := req.Messages[0].Content[0].ToolResult
@@ -1037,8 +1037,8 @@ func TestBuildRequest_ToolResultVideo(t *testing.T) {
 
 	t.Run("S3", func(t *testing.T) {
 		req, warnings, _ := mustBuildRequest(t, testAnthropicModel, toolResultFileCallOptions(provider.ToolResultContentValue{
-			Type:      provider.ToolContentFileURL,
-			URL:       "s3://bucket/video.mov",
+			Type:      provider.ToolContentFile,
+			Data:      &provider.DataContent{URL: "s3://bucket/video.mov"},
 			MediaType: "video/quicktime",
 		}))
 		result := req.Messages[0].Content[0].ToolResult

--- a/providers/bedrock/convert_request_test.go
+++ b/providers/bedrock/convert_request_test.go
@@ -814,8 +814,8 @@ func TestBuildRequest_ToolResultDocument(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			req, warnings, _ := mustBuildRequest(t, testAnthropicModel, toolResultFileCallOptions(provider.ToolResultContentValue{
-				Type:            provider.ToolContentFileData,
-				Data:            "base64data",
+				Type:            provider.ToolContentFile,
+				Data:            &provider.DataContent{Base64: "base64data"},
 				MediaType:       tt.mediaType,
 				Filename:        tt.filename,
 				ProviderOptions: tt.providerOptions,
@@ -844,8 +844,8 @@ func TestBuildRequest_ToolResultDocument(t *testing.T) {
 
 func TestBuildRequest_ToolResultImage(t *testing.T) {
 	req, warnings, _ := mustBuildRequest(t, testAnthropicModel, toolResultFileCallOptions(provider.ToolResultContentValue{
-		Type:      provider.ToolContentFileData,
-		Data:      "base64data",
+		Type:      provider.ToolContentFile,
+		Data:      &provider.DataContent{Base64: "base64data"},
 		MediaType: "image/jpeg",
 	}))
 
@@ -877,8 +877,8 @@ func TestBuildRequest_UnsupportedToolResultFileMediaType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.mediaType, func(t *testing.T) {
 			_, _, _, err := buildRequest(testAnthropicModel, toolResultFileCallOptions(provider.ToolResultContentValue{
-				Type:      provider.ToolContentFileData,
-				Data:      "base64data",
+				Type:      provider.ToolContentFile,
+				Data:      &provider.DataContent{Base64: "base64data"},
 				MediaType: tt.mediaType,
 			}))
 
@@ -895,8 +895,8 @@ func TestBuildRequest_DocumentNamesShareCounterWithToolResults(t *testing.T) {
 			provider.NewToolMessage(provider.ToolResultPart("call-123", "document-reader", &provider.ToolResultOutput{
 				Type: provider.ToolOutputContent,
 				Content: []provider.ToolResultContentValue{{
-					Type:      provider.ToolContentFileData,
-					Data:      "base64data",
+					Type:      provider.ToolContentFile,
+					Data:      &provider.DataContent{Base64: "base64data"},
 					MediaType: "application/pdf",
 				}},
 			})),

--- a/providers/bedrock/convert_request_test.go
+++ b/providers/bedrock/convert_request_test.go
@@ -860,6 +860,23 @@ func TestBuildRequest_ToolResultImage(t *testing.T) {
 	assert.Empty(t, warnings)
 }
 
+func TestBuildRequest_ToolResultEmptyData(t *testing.T) {
+	emptyData := provider.Base64DataContent("")
+	req, warnings, _ := mustBuildRequest(t, testAnthropicModel, toolResultFileCallOptions(provider.ToolResultContentValue{
+		Type:      provider.ToolContentFile,
+		Data:      &emptyData,
+		MediaType: "image/jpeg",
+	}))
+
+	require.Len(t, req.Messages, 1)
+	result := req.Messages[0].Content[0].ToolResult
+	require.NotNil(t, result)
+	require.Len(t, result.Content, 1)
+	require.NotNil(t, result.Content[0].Image)
+	assert.Empty(t, result.Content[0].Image.Source.Bytes)
+	assert.Empty(t, warnings)
+}
+
 func TestBuildRequest_UnsupportedToolResultFileMediaType(t *testing.T) {
 	tests := []struct {
 		mediaType     string

--- a/providers/bedrock/upstream_5_0_30_test.go
+++ b/providers/bedrock/upstream_5_0_30_test.go
@@ -30,8 +30,8 @@ func TestConvertPrompt_UpstreamFiveZeroThirty(t *testing.T) {
 		output := &provider.ToolResultOutput{
 			Type: provider.ToolOutputContent,
 			Content: []provider.ToolResultContentValue{{
-				Type:      provider.ToolContentFileURL,
-				URL:       "s3://my-test-bucket/path/to/image.png",
+				Type:      provider.ToolContentFile,
+				Data:      &provider.DataContent{URL: "s3://my-test-bucket/path/to/image.png"},
 				MediaType: "image/png",
 			}},
 		}

--- a/providers/openai/convert_provider_tool_continuation.go
+++ b/providers/openai/convert_provider_tool_continuation.go
@@ -672,7 +672,7 @@ func customToolCallOutputItem(part provider.ContentPart, ctx inputConversionCont
 			}
 			options := ctx.contentOptions(value)
 			switch {
-			case value.Data.URL != "":
+			case value.Data.IsURL():
 				if topLevelMediaType(value.MediaType) == "image" {
 					image := responses.ResponseInputImageParam{ImageURL: param.NewOpt(value.Data.URL)}
 					if options.ImageDetail != "" {
@@ -689,7 +689,7 @@ func customToolCallOutputItem(part provider.ContentPart, ctx inputConversionCont
 					}
 					content = append(content, responses.ResponseCustomToolCallOutputOutputOutputContentListItemUnionParam{OfInputFile: &file})
 				}
-			case value.Data.Base64 != "" || len(value.Data.Bytes) > 0:
+			case value.Data.IsData():
 				base64Data := value.Data.Base64
 				if base64Data == "" {
 					base64Data = base64.StdEncoding.EncodeToString(value.Data.Bytes)

--- a/providers/openai/convert_provider_tool_continuation.go
+++ b/providers/openai/convert_provider_tool_continuation.go
@@ -2,6 +2,7 @@ package openai
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -661,46 +662,64 @@ func customToolCallOutputItem(part provider.ContentPart, ctx inputConversionCont
 				text.SetExtraFields(map[string]any{"prompt_cache_breakpoint": breakpoint})
 			}
 			content = append(content, responses.ResponseCustomToolCallOutputOutputOutputContentListItemUnionParam{OfInputText: &text})
-		case provider.ToolContentFileURL:
-			options := ctx.contentOptions(value)
-			if topLevelMediaType(value.MediaType) == "image" {
-				image := responses.ResponseInputImageParam{ImageURL: param.NewOpt(value.URL)}
-				if options.ImageDetail != "" {
-					image.Detail = responses.ResponseInputImageDetail(options.ImageDetail)
-				}
-				if options.PromptCacheBreakpoint != nil {
-					image.SetExtraFields(map[string]any{"prompt_cache_breakpoint": options.PromptCacheBreakpoint})
-				}
-				content = append(content, responses.ResponseCustomToolCallOutputOutputOutputContentListItemUnionParam{OfInputImage: &image})
-			} else {
-				file := responses.ResponseInputFileParam{FileURL: param.NewOpt(value.URL)}
-				if options.PromptCacheBreakpoint != nil {
-					file.SetExtraFields(map[string]any{"prompt_cache_breakpoint": options.PromptCacheBreakpoint})
-				}
-				content = append(content, responses.ResponseCustomToolCallOutputOutputOutputContentListItemUnionParam{OfInputFile: &file})
+		case provider.ToolContentFile:
+			if value.Data == nil {
+				warnings = append(warnings, provider.Warning{
+					Type:    provider.WarnOther,
+					Message: "unsupported custom tool file content without data",
+				})
+				continue
 			}
-		case provider.ToolContentFileData:
 			options := ctx.contentOptions(value)
-			uri := dataURI(value.MediaType, value.Data)
-			if topLevelMediaType(value.MediaType) == "image" {
-				image := responses.ResponseInputImageParam{ImageURL: param.NewOpt(uri)}
-				if options.ImageDetail != "" {
-					image.Detail = responses.ResponseInputImageDetail(options.ImageDetail)
+			switch {
+			case value.Data.URL != "":
+				if topLevelMediaType(value.MediaType) == "image" {
+					image := responses.ResponseInputImageParam{ImageURL: param.NewOpt(value.Data.URL)}
+					if options.ImageDetail != "" {
+						image.Detail = responses.ResponseInputImageDetail(options.ImageDetail)
+					}
+					if options.PromptCacheBreakpoint != nil {
+						image.SetExtraFields(map[string]any{"prompt_cache_breakpoint": options.PromptCacheBreakpoint})
+					}
+					content = append(content, responses.ResponseCustomToolCallOutputOutputOutputContentListItemUnionParam{OfInputImage: &image})
+				} else {
+					file := responses.ResponseInputFileParam{FileURL: param.NewOpt(value.Data.URL)}
+					if options.PromptCacheBreakpoint != nil {
+						file.SetExtraFields(map[string]any{"prompt_cache_breakpoint": options.PromptCacheBreakpoint})
+					}
+					content = append(content, responses.ResponseCustomToolCallOutputOutputOutputContentListItemUnionParam{OfInputFile: &file})
 				}
-				if options.PromptCacheBreakpoint != nil {
-					image.SetExtraFields(map[string]any{"prompt_cache_breakpoint": options.PromptCacheBreakpoint})
+			case value.Data.Base64 != "" || len(value.Data.Bytes) > 0:
+				base64Data := value.Data.Base64
+				if base64Data == "" {
+					base64Data = base64.StdEncoding.EncodeToString(value.Data.Bytes)
 				}
-				content = append(content, responses.ResponseCustomToolCallOutputOutputOutputContentListItemUnionParam{OfInputImage: &image})
-			} else {
-				filename := value.Filename
-				if filename == "" {
-					filename = "data"
+				uri := dataURI(value.MediaType, base64Data)
+				if topLevelMediaType(value.MediaType) == "image" {
+					image := responses.ResponseInputImageParam{ImageURL: param.NewOpt(uri)}
+					if options.ImageDetail != "" {
+						image.Detail = responses.ResponseInputImageDetail(options.ImageDetail)
+					}
+					if options.PromptCacheBreakpoint != nil {
+						image.SetExtraFields(map[string]any{"prompt_cache_breakpoint": options.PromptCacheBreakpoint})
+					}
+					content = append(content, responses.ResponseCustomToolCallOutputOutputOutputContentListItemUnionParam{OfInputImage: &image})
+				} else {
+					filename := value.Filename
+					if filename == "" {
+						filename = "data"
+					}
+					file := responses.ResponseInputFileParam{FileData: param.NewOpt(uri), Filename: param.NewOpt(filename)}
+					if options.PromptCacheBreakpoint != nil {
+						file.SetExtraFields(map[string]any{"prompt_cache_breakpoint": options.PromptCacheBreakpoint})
+					}
+					content = append(content, responses.ResponseCustomToolCallOutputOutputOutputContentListItemUnionParam{OfInputFile: &file})
 				}
-				file := responses.ResponseInputFileParam{FileData: param.NewOpt(uri), Filename: param.NewOpt(filename)}
-				if options.PromptCacheBreakpoint != nil {
-					file.SetExtraFields(map[string]any{"prompt_cache_breakpoint": options.PromptCacheBreakpoint})
-				}
-				content = append(content, responses.ResponseCustomToolCallOutputOutputOutputContentListItemUnionParam{OfInputFile: &file})
+			default:
+				warnings = append(warnings, provider.Warning{
+					Type:    provider.WarnOther,
+					Message: "unsupported custom tool file data variant",
+				})
 			}
 		default:
 			warnings = append(warnings, provider.Warning{

--- a/providers/openai/convert_request_test.go
+++ b/providers/openai/convert_request_test.go
@@ -1010,10 +1010,15 @@ func TestBuildParams_CustomToolContentOptions(t *testing.T) {
 					ProviderOptions: provider.BuildProviderOptions(OpenAIPartOptions{PromptCacheBreakpoint: breakpoint}),
 				},
 				{
-					Type:            provider.ToolContentFileURL,
-					URL:             "https://example.com/image.png",
+					Type:            provider.ToolContentFile,
+					Data:            &provider.DataContent{URL: "https://example.com/image.png"},
 					MediaType:       "image/png",
 					ProviderOptions: provider.BuildProviderOptions(OpenAIPartOptions{ImageDetail: "high"}),
+				},
+				{
+					Type:      provider.ToolContentFile,
+					Data:      &provider.DataContent{Base64: "aW1hZ2U="},
+					MediaType: "image/png",
 				},
 			},
 		}))},
@@ -1022,9 +1027,11 @@ func TestBuildParams_CustomToolContentOptions(t *testing.T) {
 	})
 
 	output := findInput(body, "custom_tool_call_output")["output"].([]any)
-	require.Len(t, output, 2)
+	require.Len(t, output, 3)
 	assert.Equal(t, map[string]any{"mode": "explicit"}, output[0].(map[string]any)["prompt_cache_breakpoint"])
+	assert.Equal(t, "https://example.com/image.png", output[1].(map[string]any)["image_url"])
 	assert.Equal(t, "high", output[1].(map[string]any)["detail"])
+	assert.Equal(t, "data:image/png;base64,aW1hZ2U=", output[2].(map[string]any)["image_url"])
 }
 
 func TestBuildParams_ComputerCallRoundTrip(t *testing.T) {

--- a/providers/openai/convert_request_test.go
+++ b/providers/openai/convert_request_test.go
@@ -1000,6 +1000,7 @@ func TestBuildParams_MCPApprovalContinuation(t *testing.T) {
 func TestBuildParams_CustomToolContentOptions(t *testing.T) {
 	noStore := false
 	breakpoint := &PromptCacheBreakpoint{Mode: "explicit"}
+	emptyData := provider.Base64DataContent("")
 	body, _ := buildBody(t, "gpt-5", provider.CallOptions{
 		Prompt: []provider.Message{provider.NewToolMessage(provider.ToolResultPart("call_custom", "write_sql", &provider.ToolResultOutput{
 			Type: provider.ToolOutputContent,
@@ -1020,6 +1021,11 @@ func TestBuildParams_CustomToolContentOptions(t *testing.T) {
 					Data:      &provider.DataContent{Base64: "aW1hZ2U="},
 					MediaType: "image/png",
 				},
+				{
+					Type:      provider.ToolContentFile,
+					Data:      &emptyData,
+					MediaType: "image/png",
+				},
 			},
 		}))},
 		Tools:           []provider.Tool{{Type: provider.ToolTypeProvider, ID: toolIDCustom, Name: "write_sql"}},
@@ -1027,11 +1033,12 @@ func TestBuildParams_CustomToolContentOptions(t *testing.T) {
 	})
 
 	output := findInput(body, "custom_tool_call_output")["output"].([]any)
-	require.Len(t, output, 3)
+	require.Len(t, output, 4)
 	assert.Equal(t, map[string]any{"mode": "explicit"}, output[0].(map[string]any)["prompt_cache_breakpoint"])
 	assert.Equal(t, "https://example.com/image.png", output[1].(map[string]any)["image_url"])
 	assert.Equal(t, "high", output[1].(map[string]any)["detail"])
 	assert.Equal(t, "data:image/png;base64,aW1hZ2U=", output[2].(map[string]any)["image_url"])
+	assert.Equal(t, "data:image/png;base64,", output[3].(map[string]any)["image_url"])
 }
 
 func TestBuildParams_ComputerCallRoundTrip(t *testing.T) {

--- a/test/conformance/config_test.go
+++ b/test/conformance/config_test.go
@@ -89,6 +89,25 @@ func TestConfig_UIToolModelOutput(t *testing.T) {
 	require.Equal(t, provider.ToolOutputContent, messages[2].Content[0].Output.Type)
 }
 
+func TestToolConfig_EmptyFileDataModelOutput(t *testing.T) {
+	tool, err := (&ToolConfig{InputSchema: map[string]any{"type": "object"}, ModelOutput: &ToolModelOutputConfig{
+		Type: provider.ToolOutputContent,
+		Content: []ToolModelOutputContent{{
+			Type:      provider.ToolContentFileData,
+			Data:      "",
+			MediaType: "application/octet-stream",
+		}},
+	}}).buildTool("empty-file")
+	require.NoError(t, err)
+
+	output, err := tool.ToModelOutput(aisdk.ToolOutputContext{})
+	require.NoError(t, err)
+	require.Len(t, output.Content, 1)
+	encoded, err := json.Marshal(output.Content[0])
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"type":"file","data":{"type":"data","data":""},"mediaType":"application/octet-stream"}`, string(encoded))
+}
+
 type configCaptureModel struct {
 	streamFunc func(ctx context.Context, opts provider.CallOptions) (*provider.StreamResult, error)
 }

--- a/test/conformance/config_test.go
+++ b/test/conformance/config_test.go
@@ -78,7 +78,7 @@ func TestConfig_UIToolModelOutput(t *testing.T) {
 	require.Equal(t, provider.ToolOutputContent, output.Type)
 	require.Len(t, output.Content, 2)
 	assert.Equal(t, provider.ToolContentFile, output.Content[1].Type)
-	assert.Equal(t, &provider.DataContent{Base64: "iVBORw0KGgo="}, output.Content[1].Data)
+	assert.Equal(t, &provider.DataContent{Base64: cfg.Tools["weather"].ModelOutput.Content[1].Data}, output.Content[1].Data)
 	assert.Equal(t, "image/png", output.Content[1].MediaType)
 
 	uiMessages, err := cfg.BuildUIMessages()

--- a/test/conformance/config_test.go
+++ b/test/conformance/config_test.go
@@ -77,6 +77,8 @@ func TestConfig_UIToolModelOutput(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, provider.ToolOutputContent, output.Type)
 	require.Len(t, output.Content, 2)
+	assert.Equal(t, provider.ToolContentFile, output.Content[1].Type)
+	assert.Equal(t, &provider.DataContent{Base64: "iVBORw0KGgo="}, output.Content[1].Data)
 	assert.Equal(t, "image/png", output.Content[1].MediaType)
 
 	uiMessages, err := cfg.BuildUIMessages()

--- a/test/conformance/runner.go
+++ b/test/conformance/runner.go
@@ -484,12 +484,19 @@ func (tc *ToolConfig) buildTool(name string) (aisdk.Tool, error) {
 	if tc.ModelOutput != nil {
 		content := make([]provider.ToolResultContentValue, len(tc.ModelOutput.Content))
 		for i, value := range tc.ModelOutput.Content {
+			contentType := value.Type
+			switch contentType {
+			case provider.ToolContentFileData, provider.ToolContentFileURL, provider.ToolContentFileReference:
+				contentType = provider.ToolContentFile
+			}
 			content[i] = provider.ToolResultContentValue{
-				Type:      value.Type,
+				Type:      contentType,
 				Text:      value.Text,
-				Data:      value.Data,
 				MediaType: value.MediaType,
 				Filename:  value.Filename,
+			}
+			if value.Data != "" {
+				content[i].Data = &provider.DataContent{Base64: value.Data}
 			}
 		}
 		modelOutput := &provider.ToolResultOutput{

--- a/test/conformance/runner.go
+++ b/test/conformance/runner.go
@@ -485,8 +485,7 @@ func (tc *ToolConfig) buildTool(name string) (aisdk.Tool, error) {
 		content := make([]provider.ToolResultContentValue, len(tc.ModelOutput.Content))
 		for i, value := range tc.ModelOutput.Content {
 			contentType := value.Type
-			switch contentType {
-			case provider.ToolContentFileData, provider.ToolContentFileURL, provider.ToolContentFileReference:
+			if contentType == provider.ToolContentFileData {
 				contentType = provider.ToolContentFile
 			}
 			content[i] = provider.ToolResultContentValue{
@@ -495,8 +494,9 @@ func (tc *ToolConfig) buildTool(name string) (aisdk.Tool, error) {
 				MediaType: value.MediaType,
 				Filename:  value.Filename,
 			}
-			if value.Data != "" {
-				content[i].Data = &provider.DataContent{Base64: value.Data}
+			if value.Type == provider.ToolContentFileData {
+				data := provider.Base64DataContent(value.Data)
+				content[i].Data = &data
 			}
 		}
 		modelOutput := &provider.ToolResultOutput{


### PR DESCRIPTION
## Summary

- Decode LanguageModelV4 multipart tool results as canonical `type: "file"` values with nested tagged `DataContent` (`data`, `url`, `reference`, or `text`).
- Keep decoder compatibility for legacy `file-data`, `file-url`, and `file-reference` wire values while always emitting canonical V4 JSON.
- Preserve provider conversion behavior across Anthropic, Bedrock, and OpenAI, including stacked Bedrock video/S3 URL support and empty inline data.
- Fail closed for missing, null, unknown, conflicting, or malformed tagged union fields instead of silently dropping payloads.

The registered baseline is `@ai-sdk/provider@4.0.7` and `@ai-sdk/gateway@4.0.52`. In the pinned provider source, `LanguageModelV4ToolResultOutput` defines content files as `{ type: 'file', data: SharedV4FileData, mediaType, filename? }`; `SharedV4FileData` is the tagged `data | url | reference | text` union. Pinned Gateway 4.0.52 preserves that outer file value and only converts nested `Uint8Array` data to base64 before sending the provider-wire request.

## Code Changes

- Provider contract: replace the legacy flat file fields with `ToolContentFile` plus `*DataContent`, add exact variant-aware JSON codecs, preserve empty tagged values, and validate required union fields.
- Provider-wire coverage: decode the exact Gateway tool-result request shape and retain legacy decoder normalization.
- Provider conversion: adapt Anthropic, Bedrock, and OpenAI tool-result conversion to the canonical representation without dropping existing inline, URL, image, document, video, or provider-option behavior.
- Conformance and specs: normalize the legacy fixture input at the harness boundary and update active OpenSpec contracts to describe canonical V4 and decode-only legacy tolerance.

## Tests And Fixtures

- Add canonical and legacy round-trip coverage for all tagged file-data variants, empty values, malformed payloads, missing fields, unknown discriminators, and conflicting sources.
- Cover the `ui-tool-model-output` provider-wire path through Anthropic and Grafana conformance.
- Preserve focused Anthropic, Bedrock, and OpenAI multipart tool-result behavior, including Bedrock S3/video and empty inline data.

## Validation

- `mise run test`
- `mise run vet`
- `mise run lint`
- `CI=true mise run parity-check`
- `python3 scripts/lint-docs.py`
- `cd test/conformance && go test -tags conformance ./... -run 'TestConfig_UIToolModelOutput|TestToolConfig_EmptyFileDataModelOutput|TestConformance/recorded/ui-tool-model-output'`

## Residual Risk

- This intentionally changes the public Go construction shape from flat `Data string` / `URL` / `ProviderReference` fields to canonical `Data *DataContent`; legacy wire decoding remains supported, but source compatibility is not retained.
- Provider support for URL, reference, and inline-text file variants remains provider-specific; this PR preserves existing provider capabilities rather than expanding them.

## Stack

1. [#43](https://github.com/grafana/ai-sdk/pull/43) — 1/4, forward parts after stream errors
2. [#44](https://github.com/grafana/ai-sdk/pull/44) — 2/4, preserve empty providerwire stream deltas
3. [#45](https://github.com/grafana/ai-sdk/pull/45) — 3/4, omit empty Anthropic auto tool choice
4. **This PR — 4/4, decode tool-result file data unions**

Review and merge the stack in order.

