### PR TITLE
fix(agentobservability): prevent generation telemetry loss

### DIFF
--- a/middleware/agentobservability/conformance_fixtures_test.go
+++ b/middleware/agentobservability/conformance_fixtures_test.go
@@ -309,7 +309,10 @@ func hookInputs() map[string]hookFixtureInput {
 			TransformedInput: &agento11y.HookInput{
 				Messages: []agento11y.Message{
 					{Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("modified question")}},
-					{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.TextPart("Here is your answer")}},
+					{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{
+						agento11y.ThinkingPart("thinking…"),
+						agento11y.TextPart("Here is your answer"),
+					}},
 				},
 			},
 		},

--- a/middleware/agentobservability/conformance_test.go
+++ b/middleware/agentobservability/conformance_test.go
@@ -177,7 +177,9 @@ func TestConformance_Hooks(t *testing.T) {
 					// Allow without transform: prompt is unchanged.
 					got = originalPrompt
 				} else {
-					got = applyTransformedInput(originalPrompt, *hookResp.TransformedInput)
+					var err error
+					got, err = applyTransformedInput(originalPrompt, *hookResp.TransformedInput)
+					require.NoError(t, err)
 				}
 				if regenerateConformanceFixtures {
 					writeJSONFile(t, filepath.Join(dir, "expected_prompt.json"), got)

--- a/middleware/agentobservability/errors.go
+++ b/middleware/agentobservability/errors.go
@@ -6,9 +6,14 @@ import (
 	"strings"
 )
 
-// ErrHookDenied is the sentinel error wrapped by every *HookDenialError. Use
-// errors.Is(err, agentobservability.ErrHookDenied) for generic deny detection.
-var ErrHookDenied = errors.New("agent observability: hook denied request")
+var (
+	// ErrHookDenied is the sentinel error wrapped by every *HookDenialError. Use
+	// errors.Is(err, agentobservability.ErrHookDenied) for generic deny detection.
+	ErrHookDenied = errors.New("agent observability: hook denied request")
+	// ErrHookTransformFailed indicates that a hook-provided replacement could
+	// not be applied without losing or restoring request content.
+	ErrHookTransformFailed = errors.New("agent observability: hook transform failed")
+)
 
 // HookDenialError is returned by HooksMiddleware when the Agent Observability
 // preflight hook responds with action "deny". Consumers can use errors.As to

--- a/middleware/agentobservability/generation.go
+++ b/middleware/agentobservability/generation.go
@@ -76,10 +76,15 @@ func MapGenerateResult(params provider.CallOptions, result *provider.GenerateRes
 }
 
 func mapGenerateResultWithStart(params provider.CallOptions, result *provider.GenerateResult, ctxInfo ContextInfo, start agento11y.GenerationStart) agento11y.Generation {
-	system, input := messagesToAgento11y(params.Prompt)
+	system, input := messagesToAgento11yWithTools(params.Prompt, params.Tools)
 	controls := controlsFromCallOptions(params)
+	metadata := mergeMetadata(ctxInfo.Metadata, metadataFromProviderOptions(params))
+	if result != nil {
+		metadata = mergeMetadata(metadata, metadataFromUsage(result.Usage))
+	}
 
 	generation := agento11y.Generation{
+		ResponseModel:       start.Model.Name,
 		UserID:              ctxInfo.UserID,
 		AgentName:           ctxInfo.AgentName,
 		AgentVersion:        ctxInfo.AgentVersion,
@@ -93,11 +98,11 @@ func mapGenerateResultWithStart(params provider.CallOptions, result *provider.Ge
 		ThinkingEnabled:     thinkingEnabledFromAnthropic(params.ProviderOptions),
 		ParentGenerationIDs: nil, // filled by recorder seed
 		Tags:                cloneStringMap(ctxInfo.Tags),
-		Metadata:            mergeMetadata(metadataFromProviderOptions(params), ctxInfo.Metadata),
+		Metadata:            metadata,
 	}
 
 	if result != nil {
-		generation.Output = contentToAgento11yOutput(result.Content)
+		generation.Output = contentToAgento11yOutputWithTools(result.Content, params.Tools)
 		generation.Usage = usageToAgento11y(result.Usage)
 		generation.StopReason = finishReasonToAgento11yStop(result.FinishReason)
 		if result.Response != nil {
@@ -144,12 +149,8 @@ func addTransportMetadata(gen *agento11y.Generation, seed generationModelIdentit
 	if gen.Metadata == nil {
 		gen.Metadata = map[string]any{}
 	}
-	if _, ok := gen.Metadata[transportProviderMetadataKey]; !ok {
-		gen.Metadata[transportProviderMetadataKey] = seed.provider
-	}
-	if _, ok := gen.Metadata[transportModelMetadataKey]; !ok {
-		gen.Metadata[transportModelMetadataKey] = seed.model
-	}
+	gen.Metadata[transportProviderMetadataKey] = seed.provider
+	gen.Metadata[transportModelMetadataKey] = seed.model
 }
 
 // mergeMetadata returns the union of two metadata maps. Override entries win

--- a/middleware/agentobservability/generation_test.go
+++ b/middleware/agentobservability/generation_test.go
@@ -173,6 +173,46 @@ func TestMapGenerateResult_CanonicalRoundTrip(t *testing.T) {
 	assert.Empty(t, gen.SpanID, "SpanID is set by recorder")
 }
 
+func TestMapGenerateResult_ServerToolUsageMetadata(t *testing.T) {
+	result := &provider.GenerateResult{Usage: provider.Usage{
+		Raw: json.RawMessage(`{"server_tool_use":{"web_search_requests":2,"web_fetch_requests":1}}`),
+	}}
+	gen := MapGenerateResult(provider.CallOptions{}, result, ContextInfo{Metadata: map[string]any{
+		MetadataServerToolUseTotalRequests: "caller override",
+	}})
+
+	assert.Equal(t, int64(2), gen.Metadata[MetadataServerToolUseWebSearchRequests])
+	assert.Equal(t, int64(1), gen.Metadata[MetadataServerToolUseWebFetchRequests])
+	assert.Equal(t, int64(3), gen.Metadata[MetadataServerToolUseTotalRequests])
+}
+
+func TestMapGenerateResult_ResponseTransportMetadataOverridesCallerValues(t *testing.T) {
+	gen := mapGenerateResultWithStart(
+		provider.CallOptions{},
+		&provider.GenerateResult{Response: &provider.GenerateResponse{ResponseMetadata: provider.ResponseMetadata{
+			Provider: "anthropic", ModelID: "response-model",
+		}}},
+		ContextInfo{Metadata: map[string]any{
+			transportProviderMetadataKey: "spoofed-provider",
+			transportModelMetadataKey:    "spoofed-model",
+		}},
+		agento11y.GenerationStart{Model: agento11y.ModelRef{Provider: "grafana", Name: "requested-model"}},
+	)
+
+	assert.Equal(t, "grafana", gen.Metadata[transportProviderMetadataKey])
+	assert.Equal(t, "requested-model", gen.Metadata[transportModelMetadataKey])
+}
+
+func TestMapGenerateResult_ResponseModelFallsBackToRequestModel(t *testing.T) {
+	gen := mapGenerateResultWithStart(
+		provider.CallOptions{},
+		&provider.GenerateResult{},
+		ContextInfo{},
+		agento11y.GenerationStart{Model: agento11y.ModelRef{Name: "request-model"}},
+	)
+	assert.Equal(t, "request-model", gen.ResponseModel)
+}
+
 func TestMapGenerateResult_NilResult(t *testing.T) {
 	gen := MapGenerateResult(provider.CallOptions{
 		Prompt: []provider.Message{provider.UserText("hi")},

--- a/middleware/agentobservability/hooks.go
+++ b/middleware/agentobservability/hooks.go
@@ -1,8 +1,11 @@
 package agentobservability
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/grafana/agento11y/go/agento11y"
@@ -30,10 +33,9 @@ import (
 //     model.
 //  6. On allow (no TransformedInput): the inner model is invoked unchanged.
 //  7. On allow + TransformedInput: params.Prompt is rebuilt via
-//     applyTransformedInput, preserving original reasoning-block signatures
-//     where the assistant text matches; the inner model is then invoked
-//     with the new params (bypassing the middleware-level DoGenerate/DoStream
-//     closures, which captured the pre-transform params).
+//     applyTransformedInput. A transform that cannot be applied without
+//     losing request content fails closed; the inner model is otherwise
+//     invoked with the new params.
 func HooksMiddleware(opts HooksOptions) middleware.Middleware {
 	return middleware.Middleware{
 		WrapGenerate: func(ctx context.Context, p middleware.WrapGenerateParams) (*provider.GenerateResult, error) {
@@ -121,14 +123,25 @@ func evaluateHook(ctx context.Context, opts HooksOptions, model provider.Languag
 		return nil, denialErr
 	}
 
-	if resp.TransformedInput != nil && (len(resp.TransformedInput.Messages) > 0 || resp.TransformedInput.SystemPrompt != "") {
-		newPrompt := applyTransformedInput(params.Prompt, *resp.TransformedInput)
-		if len(newPrompt) > 0 {
-			span.SetAttributes(attribute.String(SpanAttrHooksResult, "transform"))
-			newParams := params
-			newParams.Prompt = newPrompt
-			return &newParams, nil
+	if resp.TransformedInput != nil {
+		newPrompt, err := applyTransformedInputWithTools(params.Prompt, params.Tools, *resp.TransformedInput)
+		if err == nil {
+			var tools []provider.Tool
+			tools, err = applyTransformedTools(params.Tools, resp.TransformedInput.Tools)
+			if err == nil {
+				err = validateTransformedToolChoice(params.ToolChoice, tools)
+			}
+			if err == nil {
+				span.SetAttributes(attribute.String(SpanAttrHooksResult, "transform"))
+				newParams := params
+				newParams.Prompt = newPrompt
+				newParams.Tools = tools
+				return &newParams, nil
+			}
 		}
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
 	}
 
 	span.SetAttributes(attribute.String(SpanAttrHooksResult, "allow"))
@@ -139,7 +152,7 @@ func evaluateHook(ctx context.Context, opts HooksOptions, model provider.Languag
 // Media is excluded because hooks predate Agent Observability media recording,
 // and sending inline data or signed URLs would widen the preflight disclosure boundary.
 func buildHookEvaluateRequest(model provider.LanguageModel, params provider.CallOptions, ctxInfo ContextInfo) agento11y.HookEvaluateRequest {
-	system, msgs := messagesToAgento11yWithMedia(params.Prompt, false)
+	system, msgs := messagesToAgento11yWithMediaAndTools(params.Prompt, false, params.Tools)
 	tools := toolsToAgento11y(params.Tools)
 
 	hookCtx := agento11y.HookContext{
@@ -185,164 +198,224 @@ func flattenMessagesForPreview(messages []agento11y.Message) string {
 	return strings.Join(parts, "\n")
 }
 
-// applyTransformedInput rebuilds an ai-sdk prompt from an agento11y.HookInput
-// while preserving the cryptographic signatures attached to reasoning blocks
-// in the original prompt's assistant messages and the system prompt that
-// the hook did not explicitly modify.
-//
-// Algorithm (matching the legacy claude path's findMatchingOriginalWithThinking):
-//
-//  1. System messages: if transformed.SystemPrompt is non-empty, replace the
-//     original system context with a single SystemMessage built from it;
-//     otherwise carry the original system messages forward unchanged. This
-//     mirrors how messagesToAgento11y folds system messages into a separate
-//     HookInput.SystemPrompt field — a hook that doesn't touch the system
-//     context returns it as "" (the zero value), and we MUST NOT silently
-//     drop the originals in that case.
-//  2. Non-system messages: index the original assistant-role messages that
-//     carry a reasoning part by their concatenated text content (excluding
-//     reasoning text). For each transformed message:
-//     - If role is assistant AND the same concatenated text appears in the
-//     index AND has not yet been consumed, keep the original message
-//     verbatim (preserves the signature).
-//     - Otherwise, rebuild the message from the transformed SDK parts.
-//
-// Reasoning signatures don't round-trip through the underlying SDK wire schema, so any
-// assistant message whose text the hook changed loses its signature.
-func applyTransformedInput(originalPrompt []provider.Message, transformed agento11y.HookInput) []provider.Message {
-	originalsWithReasoning := indexAssistantReasoningMessages(originalPrompt)
-	used := make(map[int]bool, len(originalsWithReasoning))
+// applyTransformedInput rebuilds a complete replacement prompt from a hook
+// response. It preserves reasoning signatures only on unchanged reasoning
+// parts and rejects transformations that cannot be represented faithfully.
+func applyTransformedInput(originalPrompt []provider.Message, transformed agento11y.HookInput) ([]provider.Message, error) {
+	return applyTransformedInputWithTools(originalPrompt, nil, transformed)
+}
 
-	systemMsgs := systemMessagesForTransform(originalPrompt, transformed)
+func applyTransformedInputWithTools(originalPrompt []provider.Message, tools []provider.Tool, transformed agento11y.HookInput) ([]provider.Message, error) {
+	if err := validateTransformablePrompt(originalPrompt); err != nil {
+		return nil, err
+	}
+	if len(transformed.Messages) == 0 && transformed.SystemPrompt == "" {
+		return nil, fmt.Errorf("%w: transformed input is empty", ErrHookTransformFailed)
+	}
 
-	body := make([]provider.Message, 0, len(transformed.Messages))
-	for _, agento11yMsg := range transformed.Messages {
-		role, ok := agento11yRoleToProvider(agento11yMsg.Role)
+	out := make([]provider.Message, 0, len(transformed.Messages)+1)
+	if transformed.SystemPrompt != "" {
+		out = append(out, provider.NewSystemMessage(transformed.SystemPrompt))
+	}
+
+	matcher := newTransformedPartMatcher(originalPrompt, tools)
+	for i, msg := range transformed.Messages {
+		role, ok := agento11yRoleToProvider(msg.Role)
 		if !ok {
-			continue
+			return nil, fmt.Errorf("%w: message %d has unsupported role %q", ErrHookTransformFailed, i, msg.Role)
+		}
+		if err := validateTransformedMessage(msg); err != nil {
+			return nil, fmt.Errorf("%w: message %d: %v", ErrHookTransformFailed, i, err)
 		}
 
-		if role == provider.RoleAssistant {
-			text := concatAssistantTextFromAgento11y(agento11yMsg)
-			if text != "" {
-				if idx, orig, found := findMatching(originalsWithReasoning, text, used); found {
-					used[idx] = true
-					body = append(body, orig)
-					continue
+		parts, err := rebuildPartsFromAgento11y(msg.Parts, matcher)
+		if err != nil {
+			return nil, fmt.Errorf("%w: message %d: %v", ErrHookTransformFailed, i, err)
+		}
+		if len(parts) == 0 {
+			return nil, fmt.Errorf("%w: message %d has no supported parts", ErrHookTransformFailed, i)
+		}
+		out = append(out, provider.Message{Role: role, Content: parts})
+	}
+	return out, nil
+}
+
+func validateTransformablePrompt(prompt []provider.Message) error {
+	for i, msg := range prompt {
+		if len(msg.ProviderOptions) > 0 {
+			return fmt.Errorf("%w: original message %d has undisclosed provider options", ErrHookTransformFailed, i)
+		}
+		switch msg.Role {
+		case provider.RoleSystem:
+			for _, part := range msg.Content {
+				if len(part.ProviderOptions) > 0 {
+					return fmt.Errorf("%w: original system message %d has undisclosed part provider options", ErrHookTransformFailed, i)
+				}
+				if part.Type != provider.ContentPartTypeText {
+					return fmt.Errorf("%w: original system message %d contains undisclosed %q content", ErrHookTransformFailed, i, part.Type)
+				}
+			}
+			continue
+		case provider.RoleUser, provider.RoleAssistant, provider.RoleTool:
+		default:
+			return fmt.Errorf("%w: original message %d has unsupported role %q", ErrHookTransformFailed, i, msg.Role)
+		}
+		for _, part := range msg.Content {
+			switch part.Type {
+			case provider.ContentPartTypeText:
+				if len(part.ProviderOptions) > 0 {
+					return fmt.Errorf("%w: original message %d has undisclosed text provider options", ErrHookTransformFailed, i)
+				}
+			case provider.ContentPartTypeReasoning:
+				if msg.Role != provider.RoleAssistant {
+					return fmt.Errorf("%w: original message %d has reasoning under role %q", ErrHookTransformFailed, i, msg.Role)
+				}
+				if len(part.ProviderOptions) > 0 && !hasSupportedReasoningSignature(part.ProviderOptions) {
+					return fmt.Errorf("%w: original message %d has unsupported reasoning metadata", ErrHookTransformFailed, i)
+				}
+				if part.Text == "" && len(part.ProviderOptions) > 0 {
+					return fmt.Errorf("%w: original message %d has undisclosed empty reasoning metadata", ErrHookTransformFailed, i)
+				}
+			case provider.ContentPartTypeToolCall, provider.ContentPartTypeToolResult:
+			default:
+				return fmt.Errorf("%w: original message %d contains undisclosed %q content", ErrHookTransformFailed, i, part.Type)
+			}
+		}
+	}
+	return nil
+}
+
+func hasSupportedReasoningSignature(options provider.ProviderOptions) bool {
+	if len(options) != 1 {
+		return false
+	}
+	option, ok := options["anthropic"].(provider.RawProviderOption)
+	if !ok || option.Key != "anthropic" {
+		return false
+	}
+	value, ok := decodeJSONValue(option.Raw)
+	if !ok {
+		return false
+	}
+	object, ok := value.(map[string]any)
+	if !ok || len(object) != 1 {
+		return false
+	}
+	signature, ok := object["signature"].(string)
+	return ok && signature != ""
+}
+
+func applyTransformedTools(original []provider.Tool, transformed []agento11y.ToolDefinition) ([]provider.Tool, error) {
+	if len(transformed) == 0 {
+		return nil, nil
+	}
+	used := make([]bool, len(original))
+	out := make([]provider.Tool, 0, len(transformed))
+	for i, transformedTool := range transformed {
+		if len(transformedTool.InputSchema) > 0 {
+			if _, ok := decodeJSONValue(transformedTool.InputSchema); !ok {
+				return nil, fmt.Errorf("%w: transformed tool %d has invalid input schema", ErrHookTransformFailed, i)
+			}
+		}
+		match := -1
+		for j, tool := range original {
+			mapped := toolsToAgento11y([]provider.Tool{tool})
+			if used[j] || len(mapped) != 1 || !toolDefinitionEqual(mapped[0], transformedTool) {
+				continue
+			}
+			if match >= 0 {
+				return nil, fmt.Errorf("%w: transformed tool %d is ambiguous", ErrHookTransformFailed, i)
+			}
+			match = j
+		}
+		if match < 0 {
+			return nil, fmt.Errorf("%w: transformed tool %d cannot be reconstructed", ErrHookTransformFailed, i)
+		}
+		used[match] = true
+		out = append(out, original[match])
+	}
+	return out, nil
+}
+
+func validateTransformedToolChoice(choice *provider.ToolChoice, tools []provider.Tool) error {
+	if choice == nil {
+		return nil
+	}
+	switch choice.Type {
+	case provider.ToolChoiceAuto, provider.ToolChoiceNone:
+		return nil
+	case provider.ToolChoiceRequired:
+		if len(tools) == 0 {
+			return fmt.Errorf("%w: required tool choice has no transformed tools", ErrHookTransformFailed)
+		}
+		return nil
+	case provider.ToolChoiceTool:
+		for _, tool := range tools {
+			if tool.Name == choice.ToolName {
+				return nil
+			}
+		}
+		return fmt.Errorf("%w: selected tool %q was removed by transform", ErrHookTransformFailed, choice.ToolName)
+	default:
+		return fmt.Errorf("%w: unsupported tool choice %q", ErrHookTransformFailed, choice.Type)
+	}
+}
+
+func toolDefinitionEqual(a, b agento11y.ToolDefinition) bool {
+	return a.Name == b.Name &&
+		a.Description == b.Description &&
+		a.Type == b.Type &&
+		a.Deferred == b.Deferred &&
+		jsonValueEqual(a.InputSchema, b.InputSchema)
+}
+
+func validateTransformedMessage(message agento11y.Message) error {
+	if message.Name != "" {
+		return fmt.Errorf("message name cannot be reconstructed")
+	}
+	generation := agento11y.Generation{
+		Model: agento11y.ModelRef{Provider: "hook", Name: "transform"},
+		Input: []agento11y.Message{message},
+	}
+	if err := generation.Validate(); err != nil {
+		return err
+	}
+	for i, part := range message.Parts {
+		switch part.Kind {
+		case agento11y.PartKindText:
+			if part.Metadata.ProviderType != "" {
+				return fmt.Errorf("part %d has unsupported text provider type %q", i, part.Metadata.ProviderType)
+			}
+		case agento11y.PartKindThinking:
+			if part.Metadata.ProviderType != "" && part.Metadata.ProviderType != "thinking" {
+				return fmt.Errorf("part %d has unsupported thinking provider type %q", i, part.Metadata.ProviderType)
+			}
+		case agento11y.PartKindToolCall:
+			if strings.TrimSpace(part.ToolCall.ID) == "" || strings.TrimSpace(part.ToolCall.Name) == "" {
+				return fmt.Errorf("part %d tool call requires id and name", i)
+			}
+			if len(part.ToolCall.InputJSON) > 0 {
+				if _, ok := decodeJSONValue(part.ToolCall.InputJSON); !ok {
+					return fmt.Errorf("part %d has invalid tool call JSON", i)
+				}
+			}
+		case agento11y.PartKindToolResult:
+			if strings.TrimSpace(part.ToolResult.ToolCallID) == "" || strings.TrimSpace(part.ToolResult.Name) == "" {
+				return fmt.Errorf("part %d tool result requires id and name", i)
+			}
+			hasText := part.ToolResult.Content != ""
+			hasJSON := len(part.ToolResult.ContentJSON) > 0
+			if hasText == hasJSON {
+				return fmt.Errorf("part %d tool result requires exactly one content payload", i)
+			}
+			if hasJSON {
+				if _, ok := decodeJSONValue(part.ToolResult.ContentJSON); !ok {
+					return fmt.Errorf("part %d has invalid tool result JSON", i)
 				}
 			}
 		}
-
-		parts := rebuildPartsFromAgento11y(agento11yMsg.Parts)
-		if len(parts) == 0 {
-			continue
-		}
-		body = append(body, provider.Message{Role: role, Content: parts})
 	}
-
-	if len(systemMsgs) == 0 && len(body) == 0 {
-		return nil
-	}
-
-	out := make([]provider.Message, 0, len(systemMsgs)+len(body))
-	out = append(out, systemMsgs...)
-	out = append(out, body...)
-	return out
-}
-
-// systemMessagesForTransform returns the system-role messages that should
-// precede the rebuilt non-system messages after a hook transform.
-//
-// Behavior:
-//   - transformed.SystemPrompt != "": the hook explicitly set a new system
-//     prompt → emit a single SystemMessage carrying that text. Any original
-//     system messages are replaced.
-//   - transformed.SystemPrompt == "": the hook either didn't touch the
-//     system context or explicitly cleared it. We treat the zero value as
-//     "didn't touch" — preserve the originals — because messagesToAgento11y
-//     also produces "" when the original prompt has no system messages,
-//     so the two cases are indistinguishable on the underlying SDK wire.
-//
-// This mirrors how the legacy internal Agent Observability integration
-// handled the same edge case: hooks transform what they touch and leave the
-// rest alone.
-func systemMessagesForTransform(originalPrompt []provider.Message, transformed agento11y.HookInput) []provider.Message {
-	if text := strings.TrimSpace(transformed.SystemPrompt); text != "" {
-		return []provider.Message{{
-			Role:    provider.RoleSystem,
-			Content: []provider.ContentPart{provider.TextPart(transformed.SystemPrompt)},
-		}}
-	}
-	originals := make([]provider.Message, 0)
-	for _, msg := range originalPrompt {
-		if msg.Role == provider.RoleSystem {
-			originals = append(originals, msg)
-		}
-	}
-	return originals
-}
-
-type indexedMessage struct {
-	idx     int
-	message provider.Message
-	textKey string
-}
-
-func indexAssistantReasoningMessages(prompt []provider.Message) []indexedMessage {
-	var out []indexedMessage
-	for i, msg := range prompt {
-		if msg.Role != provider.RoleAssistant {
-			continue
-		}
-		hasReasoning := false
-		for _, part := range msg.Content {
-			if part.Type == provider.ContentPartTypeReasoning {
-				hasReasoning = true
-				break
-			}
-		}
-		if !hasReasoning {
-			continue
-		}
-		out = append(out, indexedMessage{
-			idx:     i,
-			message: msg,
-			textKey: concatAssistantText(msg),
-		})
-	}
-	return out
-}
-
-func concatAssistantText(msg provider.Message) string {
-	var parts []string
-	for _, p := range msg.Content {
-		if p.Type == provider.ContentPartTypeText && p.Text != "" {
-			parts = append(parts, p.Text)
-		}
-	}
-	return strings.Join(parts, "")
-}
-
-func concatAssistantTextFromAgento11y(msg agento11y.Message) string {
-	var parts []string
-	for _, p := range msg.Parts {
-		if p.Kind == agento11y.PartKindText && p.Text != "" {
-			parts = append(parts, p.Text)
-		}
-	}
-	return strings.Join(parts, "")
-}
-
-func findMatching(originals []indexedMessage, text string, used map[int]bool) (int, provider.Message, bool) {
-	for _, m := range originals {
-		if used[m.idx] {
-			continue
-		}
-		if m.textKey == text {
-			return m.idx, m.message, true
-		}
-	}
-	return 0, provider.Message{}, false
+	return nil
 }
 
 func agento11yRoleToProvider(role agento11y.Role) (provider.Role, bool) {
@@ -358,37 +431,186 @@ func agento11yRoleToProvider(role agento11y.Role) (provider.Role, bool) {
 	}
 }
 
-// rebuildPartsFromAgento11y converts an agento11y message's parts back to ai-sdk
-// ContentParts. Reasoning parts come back WITHOUT signatures (which don't
-// round-trip through the underlying SDK wire); callers that need signature
-// preservation match against the original message via the algorithm in
-// applyTransformedInput rather than rebuilding from these parts.
-func rebuildPartsFromAgento11y(parts []agento11y.Part) []provider.ContentPart {
+type transformedPartCandidate struct {
+	part provider.ContentPart
+	used bool
+}
+
+type transformedPartMatcher struct {
+	tools       []provider.Tool
+	reasonings  []transformedPartCandidate
+	toolCalls   []transformedPartCandidate
+	toolResults []transformedPartCandidate
+}
+
+func newTransformedPartMatcher(prompt []provider.Message, tools []provider.Tool) *transformedPartMatcher {
+	matcher := &transformedPartMatcher{tools: tools}
+	for _, msg := range prompt {
+		for _, part := range msg.Content {
+			candidate := transformedPartCandidate{part: part}
+			switch part.Type {
+			case provider.ContentPartTypeReasoning:
+				matcher.reasonings = append(matcher.reasonings, candidate)
+			case provider.ContentPartTypeToolCall:
+				matcher.toolCalls = append(matcher.toolCalls, candidate)
+			case provider.ContentPartTypeToolResult:
+				matcher.toolResults = append(matcher.toolResults, candidate)
+			}
+		}
+	}
+	return matcher
+}
+
+func rebuildPartsFromAgento11y(parts []agento11y.Part, matcher *transformedPartMatcher) ([]provider.ContentPart, error) {
 	out := make([]provider.ContentPart, 0, len(parts))
-	for _, p := range parts {
+	for i, p := range parts {
+		var part provider.ContentPart
+		var err error
 		switch p.Kind {
 		case agento11y.PartKindText:
 			if p.Text == "" {
-				continue
+				return nil, fmt.Errorf("part %d has empty text", i)
 			}
-			out = append(out, provider.TextPart(p.Text))
+			part = provider.TextPart(p.Text)
 		case agento11y.PartKindThinking:
-			// Drop reasoning parts: signatures can't survive a round-trip, and
-			// callers should match against the original message instead.
-			continue
+			if p.Thinking == "" {
+				return nil, fmt.Errorf("part %d has empty thinking", i)
+			}
+			part, err = matcher.matchReasoning(p.Thinking)
 		case agento11y.PartKindToolCall:
-			if p.ToolCall == nil {
-				continue
-			}
-			out = append(out, provider.ToolCallPart(p.ToolCall.ID, p.ToolCall.Name, p.ToolCall.InputJSON))
+			part, err = matcher.matchToolCall(p.ToolCall, p.Metadata.ProviderType)
 		case agento11y.PartKindToolResult:
-			if p.ToolResult == nil {
-				continue
-			}
-			out = append(out, toolResultPartFromAgento11y(p.ToolResult))
+			part, err = matcher.matchToolResult(p.ToolResult, p.Metadata.ProviderType)
+		default:
+			return nil, fmt.Errorf("part %d has unsupported kind %q", i, p.Kind)
 		}
+		if err != nil {
+			return nil, fmt.Errorf("part %d: %w", i, err)
+		}
+		out = append(out, part)
 	}
-	return out
+	return out, nil
+}
+
+func (m *transformedPartMatcher) matchReasoning(text string) (provider.ContentPart, error) {
+	match := -1
+	for i := range m.reasonings {
+		if m.reasonings[i].used || m.reasonings[i].part.Text != text {
+			continue
+		}
+		if match >= 0 {
+			return provider.ContentPart{}, fmt.Errorf("reasoning signature is ambiguous")
+		}
+		match = i
+	}
+	if match < 0 {
+		for i := range m.reasonings {
+			if len(m.reasonings[i].part.ProviderOptions) > 0 {
+				return provider.ContentPart{}, fmt.Errorf("reasoning signature cannot be preserved")
+			}
+		}
+		return provider.ReasoningPart(text), nil
+	}
+	m.reasonings[match].used = true
+	return m.reasonings[match].part, nil
+}
+
+func (m *transformedPartMatcher) matchToolCall(call *agento11y.ToolCall, providerType string) (provider.ContentPart, error) {
+	rebuilt := provider.ToolCallPart(call.ID, call.Name, call.InputJSON)
+	match := -1
+	providerSpecific := false
+	for i := range m.toolCalls {
+		candidate := m.toolCalls[i].part
+		if candidate.ToolCallID != call.ID {
+			continue
+		}
+		mapped, _, ok := contentPartToAgento11yWithTools(candidate, true, m.tools)
+		candidateProviderType := mapped.Metadata.ProviderType
+		providerSpecific = providerSpecific || candidate.ProviderExecuted || len(candidate.ProviderOptions) > 0 ||
+			(ok && candidateProviderType != "" && candidateProviderType != "tool_use")
+		if m.toolCalls[i].used {
+			continue
+		}
+		if candidate.ToolName != call.Name || !jsonValueEqual(candidate.Input, call.InputJSON) {
+			continue
+		}
+		if !ok || candidateProviderType != providerType {
+			continue
+		}
+		if match >= 0 {
+			return provider.ContentPart{}, fmt.Errorf("tool call %q is ambiguous", call.ID)
+		}
+		match = i
+	}
+	if match >= 0 {
+		candidate := m.toolCalls[match].part
+		m.toolCalls[match].used = true
+		return candidate, nil
+	}
+	if providerSpecific || (providerType != "" && providerType != "tool_use") {
+		return provider.ContentPart{}, fmt.Errorf("provider tool call %q cannot be reconstructed", call.ID)
+	}
+	return rebuilt, nil
+}
+
+func (m *transformedPartMatcher) matchToolResult(result *agento11y.ToolResult, providerType string) (provider.ContentPart, error) {
+	rebuilt := toolResultPartFromAgento11y(result)
+	match := -1
+	providerSpecific := false
+	for i := range m.toolResults {
+		candidate := m.toolResults[i].part
+		if candidate.ToolCallID != result.ToolCallID {
+			continue
+		}
+		mapped, _, ok := contentPartToAgento11yWithTools(candidate, true, m.tools)
+		candidateProviderType := mapped.Metadata.ProviderType
+		providerSpecific = providerSpecific || candidate.ProviderExecuted || len(candidate.ProviderOptions) > 0 ||
+			(ok && candidateProviderType != "" && candidateProviderType != "tool_result")
+		if m.toolResults[i].used {
+			continue
+		}
+		if !ok || !toolResultEqual(mapped.ToolResult, result) || candidateProviderType != providerType {
+			continue
+		}
+		if match >= 0 {
+			return provider.ContentPart{}, fmt.Errorf("tool result %q is ambiguous", result.ToolCallID)
+		}
+		match = i
+	}
+	if match >= 0 {
+		candidate := m.toolResults[match].part
+		m.toolResults[match].used = true
+		return candidate, nil
+	}
+	if providerSpecific || (providerType != "" && providerType != "tool_result") {
+		return provider.ContentPart{}, fmt.Errorf("provider tool result %q cannot be reconstructed", result.ToolCallID)
+	}
+	return rebuilt, nil
+}
+
+func toolResultEqual(a, b *agento11y.ToolResult) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.ToolCallID == b.ToolCallID &&
+		a.Name == b.Name &&
+		a.IsError == b.IsError &&
+		a.Content == b.Content &&
+		jsonValueEqual(a.ContentJSON, b.ContentJSON)
+}
+
+func jsonValueEqual(a, b json.RawMessage) bool {
+	a = bytes.TrimSpace(a)
+	b = bytes.TrimSpace(b)
+	if len(a) == 0 || len(b) == 0 {
+		return len(a) == len(b)
+	}
+	if !json.Valid(a) || !json.Valid(b) {
+		return false
+	}
+	left, leftOK := decodeJSONValue(a)
+	right, rightOK := decodeJSONValue(b)
+	return leftOK && rightOK && reflect.DeepEqual(left, right)
 }
 
 func toolResultPartFromAgento11y(result *agento11y.ToolResult) provider.ContentPart {

--- a/middleware/agentobservability/hooks_test.go
+++ b/middleware/agentobservability/hooks_test.go
@@ -117,6 +117,144 @@ func TestHooksMiddleware_AllowPassesThrough(t *testing.T) {
 	assert.Equal(t, 1, model.generateHit)
 }
 
+func TestHooksMiddleware_TransformFailureDoesNotInvokeModel(t *testing.T) {
+	tests := []struct {
+		name        string
+		prompt      []provider.Message
+		transformed agento11y.HookInput
+	}{
+		{
+			name:        "empty transform",
+			prompt:      []provider.Message{provider.UserText("secret")},
+			transformed: agento11y.HookInput{},
+		},
+		{
+			name: "multimodal input",
+			prompt: []provider.Message{provider.NewUserMessage(
+				provider.TextPart("describe this"),
+				provider.FilePart("image/png", provider.DataContent{URL: "https://example.com/image.png"}),
+			)},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role:  agento11y.RoleUser,
+				Parts: []agento11y.Part{agento11y.TextPart("redacted")},
+			}}},
+		},
+		{
+			name: "message provider options",
+			prompt: []provider.Message{{
+				Role:    provider.RoleUser,
+				Content: []provider.ContentPart{provider.TextPart("input")},
+				ProviderOptions: provider.ProviderOptions{
+					"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"cacheControl":{"type":"ephemeral"}}`)},
+				},
+			}},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("filtered")},
+			}}},
+		},
+		{
+			name: "text provider options",
+			prompt: []provider.Message{provider.NewUserMessage(provider.ContentPart{
+				Type: provider.ContentPartTypeText,
+				Text: "input",
+				ProviderOptions: provider.ProviderOptions{
+					"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"cacheControl":{"type":"ephemeral"}}`)},
+				},
+			})},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("filtered")},
+			}}},
+		},
+		{
+			name: "empty reasoning metadata",
+			prompt: []provider.Message{provider.NewAssistantMessage(provider.ContentPart{
+				Type: provider.ContentPartTypeReasoning,
+				ProviderOptions: provider.ProviderOptions{
+					"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"redactedData":"secret"}`)},
+				},
+			})},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.TextPart("filtered")},
+			}}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHooksTestServer(t, agento11y.HookEvaluateResponse{
+				Action:           agento11y.HookActionAllow,
+				TransformedInput: &tc.transformed,
+			})
+			model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
+			client := h.clientWithHooksEnabled()
+			wrapped := middleware.Wrap(middleware.WrapOptions{
+				Model: model,
+				Middleware: []middleware.Middleware{HooksMiddleware(HooksOptions{
+					ClientResolver: func(context.Context) *agento11y.Client { return client },
+				})},
+			})
+
+			_, err := wrapped.DoGenerate(context.Background(), provider.CallOptions{Prompt: tc.prompt})
+			require.ErrorIs(t, err, ErrHookTransformFailed)
+			assert.Equal(t, 0, model.generateHit)
+		})
+	}
+}
+
+func TestHooksMiddleware_TransformFailureBlocksStream(t *testing.T) {
+	transformed := agento11y.HookInput{}
+	h := newHooksTestServer(t, agento11y.HookEvaluateResponse{
+		Action:           agento11y.HookActionAllow,
+		TransformedInput: &transformed,
+	})
+	model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
+	client := h.clientWithHooksEnabled()
+	wrapped := middleware.Wrap(middleware.WrapOptions{
+		Model: model,
+		Middleware: []middleware.Middleware{HooksMiddleware(HooksOptions{
+			ClientResolver: func(context.Context) *agento11y.Client { return client },
+		})},
+	})
+
+	_, err := wrapped.DoStream(context.Background(), provider.CallOptions{Prompt: []provider.Message{provider.UserText("secret")}})
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+	assert.Equal(t, 0, model.streamHit)
+}
+
+func TestHooksMiddleware_TransformAppliesToStream(t *testing.T) {
+	originalTools := []provider.Tool{
+		{Type: provider.ToolTypeFunction, Name: "keep", Description: "kept", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		{Type: provider.ToolTypeFunction, Name: "remove", Description: "removed", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+	transformed := agento11y.HookInput{
+		Messages: []agento11y.Message{{
+			Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("filtered")},
+		}},
+		Tools: toolsToAgento11y(originalTools[:1]),
+	}
+	h := newHooksTestServer(t, agento11y.HookEvaluateResponse{
+		Action: agento11y.HookActionAllow, TransformedInput: &transformed,
+	})
+	model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
+	client := h.clientWithHooksEnabled()
+	wrapped := middleware.Wrap(middleware.WrapOptions{
+		Model: model,
+		Middleware: []middleware.Middleware{HooksMiddleware(HooksOptions{
+			ClientResolver: func(context.Context) *agento11y.Client { return client },
+		})},
+	})
+
+	result, err := wrapped.DoStream(context.Background(), provider.CallOptions{
+		Prompt: []provider.Message{provider.UserText("secret")}, Tools: originalTools,
+	})
+	require.NoError(t, err)
+	for range result.Stream {
+	}
+	require.Equal(t, 1, model.streamHit)
+	require.Equal(t, []provider.Message{provider.UserText("filtered")}, model.lastParams.Prompt)
+	require.Equal(t, originalTools[:1], model.lastParams.Tools)
+}
+
 func TestBuildHookEvaluateRequest_ExcludesMedia(t *testing.T) {
 	model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
 	request := buildHookEvaluateRequest(model, provider.CallOptions{
@@ -189,11 +327,7 @@ func TestHooksMiddleware_MaxLatencyTimeout(t *testing.T) {
 	require.NoError(t, ctx.Err())
 }
 
-func TestHooksMiddleware_TransformedInput_PreservesReasoningSignature(t *testing.T) {
-	// Original assistant message carries a reasoning part with a signature.
-	// The hook returns a transform that keeps the assistant text identical.
-	// We expect the resulting prompt to keep the original assistant message
-	// verbatim (signature preserved).
+func TestHooksMiddleware_TransformedInput_PreservesReasoningSignatureWithoutRestoringRemovedParts(t *testing.T) {
 	originalReasoning := provider.ContentPart{
 		Type: provider.ContentPartTypeReasoning,
 		Text: "thinking…",
@@ -204,46 +338,500 @@ func TestHooksMiddleware_TransformedInput_PreservesReasoningSignature(t *testing
 			},
 		},
 	}
-	originalAssistant := provider.NewAssistantMessage(
-		originalReasoning,
-		provider.TextPart("Here is your answer"),
-	)
 	originalPrompt := []provider.Message{
 		provider.UserText("question"),
-		originalAssistant,
+		provider.NewAssistantMessage(
+			originalReasoning,
+			provider.ToolCallPart("call-1", "lookup", json.RawMessage(`{"query":"secret"}`)),
+			provider.TextPart("Here is your answer"),
+		),
 	}
-
-	// Hook response: same assistant text, modified user message.
 	transformed := agento11y.HookInput{
 		Messages: []agento11y.Message{
 			{Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("modified question")}},
-			{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.TextPart("Here is your answer")}},
+			{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{
+				agento11y.ThinkingPart("thinking…"),
+				agento11y.TextPart("Here is your answer"),
+			}},
 		},
 	}
 
-	newPrompt := applyTransformedInput(originalPrompt, transformed)
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
 	require.Len(t, newPrompt, 2)
-
-	assert.Equal(t, provider.RoleUser, newPrompt[0].Role)
-	require.Len(t, newPrompt[0].Content, 1)
 	assert.Equal(t, "modified question", newPrompt[0].Content[0].Text)
 
-	// Assistant message must be the original verbatim (with reasoning + signature).
 	assistant := newPrompt[1]
-	assert.Equal(t, provider.RoleAssistant, assistant.Role)
-	require.Len(t, assistant.Content, 2)
+	require.Len(t, assistant.Content, 2, "removed tool call must not be restored")
 	assert.Equal(t, provider.ContentPartTypeReasoning, assistant.Content[0].Type)
-	// Signature byte-equal preserved.
 	raw, ok := assistant.Content[0].ProviderOptions["anthropic"].(provider.RawProviderOption)
-	require.True(t, ok, "anthropic option preserved as RawProviderOption")
+	require.True(t, ok)
 	assert.JSONEq(t, `{"signature":"sig-xyz"}`, string(raw.Raw))
+	assert.Equal(t, "Here is your answer", assistant.Content[1].Text)
+}
+
+func TestHooksMiddleware_TransformedInput_DoesNotRestoreOmittedReasoning(t *testing.T) {
+	originalPrompt := []provider.Message{provider.NewAssistantMessage(
+		provider.ContentPart{
+			Type: provider.ContentPartTypeReasoning,
+			Text: "thinking",
+			ProviderOptions: provider.ProviderOptions{
+				"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"signature":"sig"}`)},
+			},
+		},
+		provider.TextPart("answer"),
+	)}
+	transformed := agento11y.HookInput{Messages: []agento11y.Message{{
+		Role:  agento11y.RoleAssistant,
+		Parts: []agento11y.Part{agento11y.TextPart("answer")},
+	}}}
+
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
+	require.Len(t, newPrompt, 1)
+	require.Len(t, newPrompt[0].Content, 1)
+	assert.Equal(t, provider.ContentPartTypeText, newPrompt[0].Content[0].Type)
+}
+
+func TestHooksMiddleware_TransformedInput_PreservesProviderToolFields(t *testing.T) {
+	originalToolCall := provider.ToolCallPart("call-1", "remote_lookup", json.RawMessage(`{"query":"x"}`))
+	originalToolCall.ProviderOptions = provider.ProviderOptions{
+		"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"type":"mcp-tool-use"}`)},
+	}
+	originalPrompt := []provider.Message{provider.NewAssistantMessage(originalToolCall)}
+	transformedCall := agento11y.ToolCallPart(agento11y.ToolCall{
+		ID: "call-1", Name: "remote_lookup", InputJSON: json.RawMessage(`{"query":"x"}`),
+	})
+	transformedCall.Metadata.ProviderType = "mcp_tool_use"
+	transformed := agento11y.HookInput{Messages: []agento11y.Message{{
+		Role:  agento11y.RoleAssistant,
+		Parts: []agento11y.Part{transformedCall},
+	}}}
+
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
+	require.Len(t, newPrompt, 1)
+	require.Len(t, newPrompt[0].Content, 1)
+	assert.False(t, newPrompt[0].Content[0].ProviderExecuted)
+	assert.Equal(t, originalToolCall.ProviderOptions, newPrompt[0].Content[0].ProviderOptions)
+}
+
+func TestHooksMiddleware_TransformedInput_MatchesSignedReasoningAfterRemovedAssistant(t *testing.T) {
+	reasoning := func(text, signature string) provider.ContentPart {
+		return provider.ContentPart{
+			Type: provider.ContentPartTypeReasoning,
+			Text: text,
+			ProviderOptions: provider.ProviderOptions{
+				"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"signature":"` + signature + `"}`)},
+			},
+		}
+	}
+	originalPrompt := []provider.Message{
+		provider.NewAssistantMessage(reasoning("first thought", "sig-1"), provider.TextPart("first")),
+		provider.NewAssistantMessage(reasoning("second thought", "sig-2"), provider.TextPart("second")),
+	}
+	transformed := agento11y.HookInput{Messages: []agento11y.Message{{
+		Role: agento11y.RoleAssistant,
+		Parts: []agento11y.Part{
+			agento11y.ThinkingPart("second thought"),
+			agento11y.TextPart("second"),
+		},
+	}}}
+
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
+	raw := newPrompt[0].Content[0].ProviderOptions["anthropic"].(provider.RawProviderOption)
+	assert.JSONEq(t, `{"signature":"sig-2"}`, string(raw.Raw))
+}
+
+func TestApplyTransformedInput_RejectsMalformedContent(t *testing.T) {
+	signedReasoning := provider.ContentPart{
+		Type: provider.ContentPartTypeReasoning,
+		Text: "original",
+		ProviderOptions: provider.ProviderOptions{
+			"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"signature":"sig"}`)},
+		},
+	}
+	tests := []struct {
+		name        string
+		original    []provider.Message
+		transformed agento11y.HookInput
+	}{
+		{
+			name:     "unknown role",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: "unknown", Parts: []agento11y.Part{agento11y.TextPart("input")},
+			}}},
+		},
+		{
+			name:     "message name",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleUser, Name: "named", Parts: []agento11y.Part{agento11y.TextPart("input")},
+			}}},
+		},
+		{
+			name:     "text provider metadata",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleUser,
+				Parts: []agento11y.Part{{
+					Kind: agento11y.PartKindText, Text: "input",
+					Metadata: agento11y.PartMetadata{ProviderType: "server_tool_use"},
+				}},
+			}}},
+		},
+		{
+			name: "original reasoning under user role",
+			original: []provider.Message{{
+				Role: provider.RoleUser,
+				Content: []provider.ContentPart{{
+					Type: provider.ContentPartTypeReasoning, Text: "thinking",
+				}},
+			}},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.ThinkingPart("thinking")},
+			}}},
+		},
+		{
+			name:     "missing tool payload",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant, Parts: []agento11y.Part{{Kind: agento11y.PartKindToolCall}},
+			}}},
+		},
+		{
+			name:     "empty tool name",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role:  agento11y.RoleAssistant,
+				Parts: []agento11y.Part{agento11y.ToolCallPart(agento11y.ToolCall{ID: "call-1"})},
+			}}},
+		},
+		{
+			name:     "empty tool call id",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role:  agento11y.RoleAssistant,
+				Parts: []agento11y.Part{agento11y.ToolCallPart(agento11y.ToolCall{Name: "lookup"})},
+			}}},
+		},
+		{
+			name:     "whitespace tool call id",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant,
+				Parts: []agento11y.Part{agento11y.ToolCallPart(agento11y.ToolCall{
+					ID: " ", Name: "lookup",
+				})},
+			}}},
+		},
+		{
+			name:     "tool call in user message",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role:  agento11y.RoleUser,
+				Parts: []agento11y.Part{agento11y.ToolCallPart(agento11y.ToolCall{Name: "lookup"})},
+			}}},
+		},
+		{
+			name:     "multiple payload fields",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant,
+				Parts: []agento11y.Part{{
+					Kind:     agento11y.PartKindToolCall,
+					Text:     "extra",
+					ToolCall: &agento11y.ToolCall{Name: "lookup"},
+				}},
+			}}},
+		},
+		{
+			name:     "invalid tool JSON",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant,
+				Parts: []agento11y.Part{agento11y.ToolCallPart(agento11y.ToolCall{
+					ID: "call-1", Name: "lookup", InputJSON: json.RawMessage(`{`),
+				})},
+			}}},
+		},
+		{
+			name:     "duplicate-key tool JSON",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant,
+				Parts: []agento11y.Part{agento11y.ToolCallPart(agento11y.ToolCall{
+					ID: "call-1", Name: "lookup", InputJSON: json.RawMessage(`{"value":1,"\u0076alue":2}`),
+				})},
+			}}},
+		},
+		{
+			name:     "invalid tool result JSON",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1", Name: "lookup", ContentJSON: json.RawMessage(`{`),
+				})},
+			}}},
+		},
+		{
+			name:     "duplicate-key tool result JSON",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1", Name: "lookup", ContentJSON: json.RawMessage(`{"value":1,"value":2}`),
+				})},
+			}}},
+		},
+		{
+			name:     "tool result without correlation",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role:  agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{})},
+			}}},
+		},
+		{
+			name:     "tool result without name",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1",
+				})},
+			}}},
+		},
+		{
+			name:     "tool result without id",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					Name: "lookup",
+				})},
+			}}},
+		},
+		{
+			name:     "whitespace tool result name",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1", Name: " ",
+				})},
+			}}},
+		},
+		{
+			name:     "tool result with both payloads",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1", Name: "lookup", Content: "text", ContentJSON: json.RawMessage(`{"value":1}`),
+				})},
+			}}},
+		},
+		{
+			name:     "tool result without payload",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1", Name: "lookup",
+				})},
+			}}},
+		},
+		{
+			name: "ambiguous signed and unsigned reasoning",
+			original: []provider.Message{provider.NewAssistantMessage(
+				signedReasoning,
+				provider.ReasoningPart("original"),
+			)},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.ThinkingPart("original")},
+			}}},
+		},
+		{
+			name: "reasoning signature with extra metadata",
+			original: []provider.Message{provider.NewAssistantMessage(provider.ContentPart{
+				Type: provider.ContentPartTypeReasoning,
+				Text: "original",
+				ProviderOptions: provider.ProviderOptions{
+					"anthropic": provider.RawProviderOption{
+						Key: "anthropic", Raw: json.RawMessage(`{"signature":"sig","extra":true}`),
+					},
+				},
+			})},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.ThinkingPart("original")},
+			}}},
+		},
+		{
+			name:     "changed signed reasoning",
+			original: []provider.Message{provider.NewAssistantMessage(signedReasoning)},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.ThinkingPart("changed")},
+			}}},
+		},
+		{
+			name: "changed provider tool result",
+			original: []provider.Message{provider.NewToolMessage(provider.ContentPart{
+				Type: provider.ContentPartTypeToolResult, ToolCallID: "call-1", ToolName: "server_tool",
+				ProviderExecuted: true,
+				Output:           &provider.ToolResultOutput{Type: provider.ToolOutputJSON, JSON: json.RawMessage(`{"value":"original"}`)},
+			})},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1", Name: "server_tool", ContentJSON: json.RawMessage(`{"value":"changed"}`),
+				})},
+			}}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := applyTransformedInput(tc.original, tc.transformed)
+			require.ErrorIs(t, err, ErrHookTransformFailed)
+		})
+	}
+}
+
+func TestApplyTransformedInput_DistinguishesLargeJSONIntegers(t *testing.T) {
+	unchangedCall := provider.ToolCallPart("call-1", "lookup", json.RawMessage(`{"value":9007199254740993}`))
+	unchangedTools := []provider.Tool{{
+		Type: provider.ToolTypeFunction, Name: "lookup",
+		InputSchema: json.RawMessage(`{"const":9007199254740993}`),
+	}}
+	_, mappedMessages := messagesToAgento11yWithMediaAndTools(
+		[]provider.Message{provider.NewAssistantMessage(unchangedCall)}, true, unchangedTools,
+	)
+	mappedTools := toolsToAgento11y(unchangedTools)
+	require.Equal(t, `{"value":9007199254740993}`, string(mappedMessages[0].Parts[0].ToolCall.InputJSON))
+	require.Equal(t, `{"const":9007199254740993}`, string(mappedTools[0].InputSchema))
+	unchanged, err := applyTransformedInputWithTools(
+		[]provider.Message{provider.NewAssistantMessage(unchangedCall)}, unchangedTools,
+		agento11y.HookInput{Messages: mappedMessages, Tools: mappedTools},
+	)
+	require.NoError(t, err)
+	require.Equal(t, `{"value":9007199254740993}`, string(unchanged[0].Content[0].Input))
+
+	originalCall := provider.ToolCallPart("call-1", "server_tool", json.RawMessage(`{"value":9007199254740992}`))
+	originalCall.ProviderExecuted = true
+	transformedCall := agento11y.ToolCallPart(agento11y.ToolCall{
+		ID: "call-1", Name: "server_tool", InputJSON: json.RawMessage(`{"value":9007199254740993}`),
+	})
+	transformedCall.Metadata.ProviderType = "server_tool_use"
+
+	_, err = applyTransformedInput(
+		[]provider.Message{provider.NewAssistantMessage(originalCall)},
+		agento11y.HookInput{Messages: []agento11y.Message{{
+			Role: agento11y.RoleAssistant, Parts: []agento11y.Part{transformedCall},
+		}}},
+	)
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+
+	duplicateInput := json.RawMessage(`{"value":1,"value":2}`)
+	require.Equal(t, string(duplicateInput), string(normalizeJSONObject(duplicateInput)))
+	duplicateCall := provider.ToolCallPart("call-2", "server_tool", duplicateInput)
+	duplicateCall.ProviderExecuted = true
+	collapsedCall := agento11y.ToolCallPart(agento11y.ToolCall{
+		ID: "call-2", Name: "server_tool", InputJSON: json.RawMessage(`{"value":2}`),
+	})
+	collapsedCall.Metadata.ProviderType = "server_tool_use"
+	_, err = applyTransformedInput(
+		[]provider.Message{provider.NewAssistantMessage(duplicateCall)},
+		agento11y.HookInput{Messages: []agento11y.Message{{
+			Role: agento11y.RoleAssistant, Parts: []agento11y.Part{collapsedCall},
+		}}},
+	)
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+
+	duplicateSchemaTools := []provider.Tool{{
+		Type: provider.ToolTypeFunction, Name: "lookup",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}}
+	duplicateSchema := toolsToAgento11y(duplicateSchemaTools)[0]
+	duplicateSchema.InputSchema = json.RawMessage(`{"type":"object","type":"array"}`)
+	_, err = applyTransformedTools(duplicateSchemaTools, []agento11y.ToolDefinition{duplicateSchema})
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+
+	originalTools := []provider.Tool{{
+		Type: provider.ToolTypeFunction, Name: "lookup",
+		InputSchema: json.RawMessage(`{"const":9007199254740992}`),
+	}}
+	transformedTool := toolsToAgento11y(originalTools)[0]
+	transformedTool.InputSchema = json.RawMessage(`{"const":9007199254740993}`)
+	_, err = applyTransformedTools(originalTools, []agento11y.ToolDefinition{transformedTool})
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+}
+
+func TestApplyTransformedInput_RequiresExactProviderDiscriminator(t *testing.T) {
+	originalCall := provider.ToolCallPart("call-1", "remote", json.RawMessage(`{"query":"x"}`))
+	originalCall.ProviderExecuted = true
+	originalCall.ProviderOptions = provider.ProviderOptions{
+		"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"type":"mcp-tool-use"}`)},
+	}
+	transformedCall := agento11y.ToolCallPart(agento11y.ToolCall{
+		ID: "call-1", Name: "remote", InputJSON: json.RawMessage(`{"query":"x"}`),
+	})
+	transformedCall.Metadata.ProviderType = "server_tool_use"
+
+	_, err := applyTransformedInput(
+		[]provider.Message{provider.NewAssistantMessage(originalCall)},
+		agento11y.HookInput{Messages: []agento11y.Message{{
+			Role: agento11y.RoleAssistant, Parts: []agento11y.Part{transformedCall},
+		}}},
+	)
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+}
+
+func TestApplyTransformedInput_PreservesAliasedProviderResult(t *testing.T) {
+	tools := []provider.Tool{{
+		Type: provider.ToolTypeProvider, ID: "anthropic.web_fetch_20250910", Name: "fetch_page",
+	}}
+	original := provider.ContentPart{
+		Type: provider.ContentPartTypeToolResult, ToolCallID: "call-1", ToolName: "fetch_page",
+		Output: &provider.ToolResultOutput{Type: provider.ToolOutputJSON, JSON: json.RawMessage(`{"url":"https://example.com"}`)},
+	}
+	_, messages := messagesToAgento11yWithMediaAndTools(
+		[]provider.Message{provider.NewToolMessage(original)}, true, tools,
+	)
+	require.Equal(t, "web_fetch_tool_result", messages[0].Parts[0].Metadata.ProviderType)
+
+	transformed, err := applyTransformedInputWithTools(
+		[]provider.Message{provider.NewToolMessage(original)}, tools,
+		agento11y.HookInput{Messages: messages, Tools: toolsToAgento11y(tools)},
+	)
+	require.NoError(t, err)
+	require.Len(t, transformed, 1)
+	assert.Equal(t, original, transformed[0].Content[0])
+
+	messages[0].Parts[0].Metadata.ProviderType = "tool_result"
+	_, err = applyTransformedInputWithTools(
+		[]provider.Message{provider.NewToolMessage(original)}, tools,
+		agento11y.HookInput{Messages: messages, Tools: toolsToAgento11y(tools)},
+	)
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+}
+
+func TestApplyTransformedInput_RejectsNewProviderSpecificPart(t *testing.T) {
+	call := agento11y.ToolCallPart(agento11y.ToolCall{ID: "call-1", Name: "server_tool"})
+	call.Metadata.ProviderType = "server_tool_use"
+	_, err := applyTransformedInput(
+		[]provider.Message{provider.UserText("input")},
+		agento11y.HookInput{Messages: []agento11y.Message{{
+			Role: agento11y.RoleAssistant, Parts: []agento11y.Part{call},
+		}}},
+	)
+	require.ErrorIs(t, err, ErrHookTransformFailed)
 }
 
 func TestHooksMiddleware_TransformedInput_ModifiedTextRebuilds(t *testing.T) {
-	// When the hook changes the assistant text, the matching algorithm
-	// can't preserve the signature; the message is rebuilt from agento11y parts
-	// (without the signature). This is the documented behavior — the wire
-	// format can't round-trip signatures.
 	originalAssistant := provider.NewAssistantMessage(
 		provider.ContentPart{
 			Type: provider.ContentPartTypeReasoning,
@@ -265,14 +853,12 @@ func TestHooksMiddleware_TransformedInput_ModifiedTextRebuilds(t *testing.T) {
 		},
 	}
 
-	newPrompt := applyTransformedInput(originalPrompt, transformed)
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
 	require.Len(t, newPrompt, 1)
 	require.Len(t, newPrompt[0].Content, 1, "rebuilt message has only the transformed text part")
+	assert.Equal(t, provider.ContentPartTypeText, newPrompt[0].Content[0].Type)
 	assert.Equal(t, "REDACTED answer", newPrompt[0].Content[0].Text)
-	// No reasoning part survived because the rebuild drops thinking parts.
-	for _, p := range newPrompt[0].Content {
-		assert.NotEqual(t, provider.ContentPartTypeReasoning, p.Type)
-	}
 }
 
 func TestHooksMiddleware_TransformedInput_NonAssistantRebuiltFromParts(t *testing.T) {
@@ -284,41 +870,40 @@ func TestHooksMiddleware_TransformedInput_NonAssistantRebuiltFromParts(t *testin
 			{Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("hello (filtered)")}},
 		},
 	}
-	newPrompt := applyTransformedInput(originalPrompt, transformed)
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
 	require.Len(t, newPrompt, 1)
 	assert.Equal(t, provider.RoleUser, newPrompt[0].Role)
 	assert.Equal(t, "hello (filtered)", newPrompt[0].Content[0].Text)
 }
 
-// TestHooksMiddleware_TransformedInput_PreservesSystemMessages guards
-// against a regression where a hook transform silently dropped the
-// original system messages: messagesToAgento11y folds them into a separate
-// HookInput.SystemPrompt field, so a hook response that only modifies user
-// messages comes back with SystemPrompt == "". applyTransformedInput must
-// treat the zero value as "didn't touch the system context" and keep the
-// originals.
-func TestHooksMiddleware_TransformedInput_PreservesSystemMessages(t *testing.T) {
+func TestHooksMiddleware_TransformedInput_DropsOmittedSystemMessages(t *testing.T) {
 	originalPrompt := []provider.Message{
 		provider.NewSystemMessage("you are helpful"),
 		provider.UserText("hello"),
 	}
 	transformed := agento11y.HookInput{
-		// SystemPrompt deliberately empty — the hook only modified the user
-		// message. Without the fix, the resulting prompt has no system.
 		Messages: []agento11y.Message{
 			{Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("hello (filtered)")}},
 		},
 	}
 
-	newPrompt := applyTransformedInput(originalPrompt, transformed)
-	require.Len(t, newPrompt, 2)
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
+	require.Len(t, newPrompt, 1)
+	assert.Equal(t, provider.RoleUser, newPrompt[0].Role)
+	assert.Equal(t, "hello (filtered)", newPrompt[0].Content[0].Text)
+}
 
+func TestHooksMiddleware_TransformedInput_SystemOnlyReplacement(t *testing.T) {
+	newPrompt, err := applyTransformedInput(
+		[]provider.Message{provider.UserText("remove me")},
+		agento11y.HookInput{SystemPrompt: "system only"},
+	)
+	require.NoError(t, err)
+	require.Len(t, newPrompt, 1)
 	assert.Equal(t, provider.RoleSystem, newPrompt[0].Role)
-	require.Len(t, newPrompt[0].Content, 1)
-	assert.Equal(t, "you are helpful", newPrompt[0].Content[0].Text)
-
-	assert.Equal(t, provider.RoleUser, newPrompt[1].Role)
-	assert.Equal(t, "hello (filtered)", newPrompt[1].Content[0].Text)
+	assert.Equal(t, "system only", newPrompt[0].Content[0].Text)
 }
 
 func TestHooksMiddleware_TransformedInput_OverridesSystemPrompt(t *testing.T) {
@@ -335,7 +920,8 @@ func TestHooksMiddleware_TransformedInput_OverridesSystemPrompt(t *testing.T) {
 		},
 	}
 
-	newPrompt := applyTransformedInput(originalPrompt, transformed)
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
 	require.Len(t, newPrompt, 2, "two originals collapsed into one transformed system")
 
 	assert.Equal(t, provider.RoleSystem, newPrompt[0].Role)
@@ -357,12 +943,103 @@ func TestHooksMiddleware_TransformedInput_AddsSystemWhenAbsent(t *testing.T) {
 		},
 	}
 
-	newPrompt := applyTransformedInput(originalPrompt, transformed)
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
 	require.Len(t, newPrompt, 2)
 
 	assert.Equal(t, provider.RoleSystem, newPrompt[0].Role)
 	assert.Equal(t, "you are helpful", newPrompt[0].Content[0].Text)
 	assert.Equal(t, provider.RoleUser, newPrompt[1].Role)
+}
+
+func TestHooksMiddleware_TransformedInput_RemovesTools(t *testing.T) {
+	originalTool := provider.Tool{
+		Type:        provider.ToolTypeFunction,
+		Name:        "lookup",
+		Description: "look up data",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}
+	transformed := agento11y.HookInput{Messages: []agento11y.Message{{
+		Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("filtered")},
+	}}}
+	h := newHooksTestServer(t, agento11y.HookEvaluateResponse{
+		Action:           agento11y.HookActionAllow,
+		TransformedInput: &transformed,
+	})
+	model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
+	client := h.clientWithHooksEnabled()
+	wrapped := middleware.Wrap(middleware.WrapOptions{
+		Model: model,
+		Middleware: []middleware.Middleware{HooksMiddleware(HooksOptions{
+			ClientResolver: func(context.Context) *agento11y.Client { return client },
+		})},
+	})
+
+	_, err := wrapped.DoGenerate(context.Background(), provider.CallOptions{
+		Prompt: []provider.Message{provider.UserText("input")},
+		Tools:  []provider.Tool{originalTool},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, model.lastParams.Tools)
+}
+
+func TestHooksMiddleware_TransformedInput_RejectsUnsatisfiedToolChoice(t *testing.T) {
+	tests := []struct {
+		name       string
+		toolChoice *provider.ToolChoice
+	}{
+		{
+			name:       "required",
+			toolChoice: &provider.ToolChoice{Type: provider.ToolChoiceRequired},
+		},
+		{
+			name:       "selected tool",
+			toolChoice: &provider.ToolChoice{Type: provider.ToolChoiceTool, ToolName: "lookup"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			transformed := agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("filtered")},
+			}}}
+			h := newHooksTestServer(t, agento11y.HookEvaluateResponse{
+				Action: agento11y.HookActionAllow, TransformedInput: &transformed,
+			})
+			model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
+			wrapped := middleware.Wrap(middleware.WrapOptions{
+				Model: model,
+				Middleware: []middleware.Middleware{HooksMiddleware(HooksOptions{
+					ClientResolver: func(context.Context) *agento11y.Client { return h.clientWithHooksEnabled() },
+				})},
+			})
+
+			_, err := wrapped.DoGenerate(context.Background(), provider.CallOptions{
+				Prompt:     []provider.Message{provider.UserText("input")},
+				Tools:      []provider.Tool{{Type: provider.ToolTypeFunction, Name: "lookup"}},
+				ToolChoice: tc.toolChoice,
+			})
+			require.ErrorIs(t, err, ErrHookTransformFailed)
+			assert.Zero(t, model.generateHit)
+		})
+	}
+}
+
+func TestApplyTransformedTools_PreservesRetainedToolsAndRejectsModifiedTools(t *testing.T) {
+	original := []provider.Tool{
+		{Type: provider.ToolTypeFunction, Name: "first", Description: "first tool"},
+		{Type: provider.ToolTypeFunction, Name: "second", Description: "second tool", Strict: boolPtr(true)},
+	}
+	mapped := toolsToAgento11y(original)
+
+	transformed, err := applyTransformedTools(original, []agento11y.ToolDefinition{mapped[1]})
+	require.NoError(t, err)
+	require.Len(t, transformed, 1)
+	assert.Equal(t, original[1], transformed[0])
+
+	modified := mapped[0]
+	modified.Description = "changed"
+	_, err = applyTransformedTools(original, []agento11y.ToolDefinition{modified})
+	require.ErrorIs(t, err, ErrHookTransformFailed)
 }
 
 func TestBuildHookEvaluateRequest(t *testing.T) {

--- a/middleware/agentobservability/map_provider_options.go
+++ b/middleware/agentobservability/map_provider_options.go
@@ -1,6 +1,10 @@
 package agentobservability
 
-import "github.com/grafana/ai-sdk/provider"
+import (
+	"encoding/json"
+
+	"github.com/grafana/ai-sdk/provider"
+)
 
 // Metadata keys mirror the upstream agento11y Anthropic helper so existing
 // dashboards and BigQuery views keep working. Adding new keys is safe;
@@ -10,15 +14,46 @@ const (
 	// thinking budget is recorded in Generation.Metadata. Mirrors
 	// agento11y/go-providers/anthropic's thinkingBudgetMetadataKey constant.
 	MetadataThinkingBudgetTokens = "agento11y.gen_ai.request.thinking.budget_tokens"
+	// MetadataServerToolUseWebSearchRequests records billed Anthropic web searches.
+	MetadataServerToolUseWebSearchRequests = "agento11y.gen_ai.usage.server_tool_use.web_search_requests"
+	// MetadataServerToolUseWebFetchRequests records billed Anthropic web fetches.
+	MetadataServerToolUseWebFetchRequests = "agento11y.gen_ai.usage.server_tool_use.web_fetch_requests"
+	// MetadataServerToolUseTotalRequests records all billed Anthropic server-tool requests.
+	MetadataServerToolUseTotalRequests = "agento11y.gen_ai.usage.server_tool_use.total_requests"
 )
 
-// metadataFromProviderOptions decodes the subset of params.ProviderOptions
-// the middleware needs to surface as agento11y.Generation.Metadata entries.
-//
-// The implementation never imports a provider module; every ProviderOptions
-// value is reached via the opaque RawProviderOption / encoding/json path. New
-// providers' options can be wired in by adding cases here without changing
-// the public API surface.
+// metadataFromUsage extracts provider usage fields that Agent Observability
+// represents as generation metadata.
+func metadataFromUsage(usage provider.Usage) map[string]any {
+	if len(usage.Raw) == 0 {
+		return nil
+	}
+	var raw struct {
+		ServerToolUse struct {
+			WebSearchRequests int64 `json:"web_search_requests"`
+			WebFetchRequests  int64 `json:"web_fetch_requests"`
+		} `json:"server_tool_use"`
+	}
+	if err := json.Unmarshal(usage.Raw, &raw); err != nil {
+		return nil
+	}
+	search := raw.ServerToolUse.WebSearchRequests
+	fetch := raw.ServerToolUse.WebFetchRequests
+	if search < 0 || fetch < 0 || search+fetch == 0 {
+		return nil
+	}
+	out := map[string]any{MetadataServerToolUseTotalRequests: search + fetch}
+	if search > 0 {
+		out[MetadataServerToolUseWebSearchRequests] = search
+	}
+	if fetch > 0 {
+		out[MetadataServerToolUseWebFetchRequests] = fetch
+	}
+	return out
+}
+
+// metadataFromProviderOptions extracts request fields that Agent Observability
+// represents as generation metadata.
 func metadataFromProviderOptions(params provider.CallOptions) map[string]any {
 	out := map[string]any{}
 	if budget := thinkingBudgetFromAnthropic(params.ProviderOptions); budget != nil {

--- a/middleware/agentobservability/map_request.go
+++ b/middleware/agentobservability/map_request.go
@@ -1,7 +1,9 @@
 package agentobservability
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"strconv"
 	"strings"
 
@@ -24,10 +26,14 @@ const systemPromptSeparator = "\n\n"
 // shape on the Anthropic wire (tool_result blocks live inside user messages
 // but the underlying SDK normalizes them to tool-role messages).
 func messagesToAgento11y(prompt []provider.Message) (string, []agento11y.Message) {
-	return messagesToAgento11yWithMedia(prompt, true)
+	return messagesToAgento11yWithMediaAndTools(prompt, true, nil)
 }
 
-func messagesToAgento11yWithMedia(prompt []provider.Message, includeMedia bool) (string, []agento11y.Message) {
+func messagesToAgento11yWithTools(prompt []provider.Message, tools []provider.Tool) (string, []agento11y.Message) {
+	return messagesToAgento11yWithMediaAndTools(prompt, true, tools)
+}
+
+func messagesToAgento11yWithMediaAndTools(prompt []provider.Message, includeMedia bool, tools []provider.Tool) (string, []agento11y.Message) {
 	if len(prompt) == 0 {
 		return "", nil
 	}
@@ -51,7 +57,7 @@ func messagesToAgento11yWithMedia(prompt []provider.Message, includeMedia bool) 
 			continue
 		}
 
-		normalParts, toolParts := convertMessageParts(msg.Content, includeMedia)
+		normalParts, toolParts := convertMessagePartsWithTools(msg.Content, includeMedia, tools)
 		if len(normalParts) > 0 {
 			out = append(out, agento11y.Message{Role: role, Parts: normalParts})
 		}
@@ -83,9 +89,9 @@ func roleToAgento11y(role provider.Role) (agento11y.Role, bool) {
 // convertMessageParts splits message content parts into (non-tool-result parts,
 // tool-result parts). The caller emits the second slice as its own
 // [agento11y.RoleTool] message when non-empty.
-func convertMessageParts(parts []provider.ContentPart, includeMedia bool) (normal, toolResults []agento11y.Part) {
+func convertMessagePartsWithTools(parts []provider.ContentPart, includeMedia bool, tools []provider.Tool) (normal, toolResults []agento11y.Part) {
 	for i := range parts {
-		part, kind, ok := contentPartToAgento11y(parts[i], includeMedia)
+		part, kind, ok := contentPartToAgento11yWithTools(parts[i], includeMedia, tools)
 		if !ok {
 			continue
 		}
@@ -103,7 +109,7 @@ func convertMessageParts(parts []provider.ContentPart, includeMedia bool) (norma
 // The returned PartKind is also returned so callers can route tool-result
 // parts into a separate message (matching the upstream Anthropic helper's
 // splitting behavior).
-func contentPartToAgento11y(part provider.ContentPart, includeMedia bool) (agento11y.Part, agento11y.PartKind, bool) {
+func contentPartToAgento11yWithTools(part provider.ContentPart, includeMedia bool, tools []provider.Tool) (agento11y.Part, agento11y.PartKind, bool) {
 	switch part.Type {
 	case provider.ContentPartTypeText:
 		if part.Text == "" {
@@ -112,6 +118,9 @@ func contentPartToAgento11y(part provider.ContentPart, includeMedia bool) (agent
 		return agento11y.TextPart(part.Text), agento11y.PartKindText, true
 
 	case provider.ContentPartTypeReasoning:
+		if part.Text == "" {
+			return agento11y.Part{}, "", false
+		}
 		out := agento11y.ThinkingPart(part.Text)
 		out.Metadata.ProviderType = "thinking"
 		return out, agento11y.PartKindThinking, true
@@ -126,7 +135,12 @@ func contentPartToAgento11y(part provider.ContentPart, includeMedia bool) (agent
 			InputJSON: normalizeJSONObject(part.Input),
 		}
 		out := agento11y.ToolCallPart(call)
-		out.Metadata.ProviderType = providerTypeForToolCall(part)
+		out.Metadata.ProviderType = providerTypeForToolWithDefinitions(
+			part.ProviderExecuted,
+			part.ToolName,
+			anthropicTypeFromOptions(part.ProviderOptions),
+			tools,
+		)
 		return out, agento11y.PartKindToolCall, true
 
 	case provider.ContentPartTypeToolResult:
@@ -137,7 +151,13 @@ func contentPartToAgento11y(part provider.ContentPart, includeMedia bool) (agent
 			IsError:     isErr,
 			ContentJSON: content,
 		})
-		out.Metadata.ProviderType = "tool_result"
+		out.Metadata.ProviderType = providerTypeForToolResult(
+			part.ProviderExecuted,
+			part.ToolName,
+			anthropicTypeFromOptions(part.ProviderOptions),
+			tools,
+			content,
+		)
 		return out, agento11y.PartKindToolResult, true
 
 	case provider.ContentPartTypeFile:
@@ -166,15 +186,112 @@ func contentPartToAgento11y(part provider.ContentPart, includeMedia bool) (agent
 	}
 }
 
-// providerTypeForToolCall recovers the Anthropic provider-type discriminator
-// for tool calls. ProviderExecuted indicates a server-side tool (web_search,
-// code_execution, …); MCP tools are not currently flagged separately at the
-// ai-sdk content layer, so they fall through to "tool_use".
+// providerTypeForToolCall recovers provider-specific tool discriminators
+// retained by the provider-neutral content layer.
 func providerTypeForToolCall(part provider.ContentPart) string {
-	if part.ProviderExecuted {
+	return providerTypeForTool(part.ProviderExecuted, part.ToolName, anthropicTypeFromOptions(part.ProviderOptions))
+}
+
+func providerTypeForTool(providerExecuted bool, toolName, anthropicType string) string {
+	return providerTypeForToolWithDefinitions(providerExecuted, toolName, anthropicType, nil)
+}
+
+func providerTypeForToolWithDefinitions(providerExecuted bool, toolName, anthropicType string, tools []provider.Tool) string {
+	if anthropicType == "mcp-tool-use" {
+		return "mcp_tool_use"
+	}
+	if !providerExecuted {
+		return "tool_use"
+	}
+	providerToolName := resolveAnthropicProviderToolName(tools, toolName)
+	if providerToolName == "" {
+		providerToolName = toolName
+	}
+	switch providerToolName {
+	case "tool_search_tool_regex", "tool_search_tool_bm25":
+		return providerToolName
+	default:
 		return "server_tool_use"
 	}
-	return "tool_use"
+}
+
+func providerTypeForToolResult(providerExecuted bool, toolName, anthropicType string, tools []provider.Tool, result json.RawMessage) string {
+	if anthropicType == "mcp-tool-use" {
+		return "mcp_tool_result"
+	}
+	providerToolName := resolveAnthropicProviderToolName(tools, toolName)
+	resolvedProviderTool := providerToolName != ""
+	if providerToolName == "" {
+		if !providerExecuted {
+			return "tool_result"
+		}
+		providerToolName = toolName
+	}
+	if providerToolName == "code_execution" && (providerExecuted || resolvedProviderTool) {
+		switch resultType := anthropicTypeFromRaw(result); {
+		case resultType == "bash_code_execution_result":
+			return "bash_code_execution_tool_result"
+		case strings.HasPrefix(resultType, "text_editor_code_execution_"):
+			return "text_editor_code_execution_tool_result"
+		}
+	}
+	switch providerToolName {
+	case "web_search":
+		return "web_search_tool_result"
+	case "web_fetch":
+		return "web_fetch_tool_result"
+	case "code_execution":
+		return "code_execution_tool_result"
+	case "tool_search_tool_regex":
+		return "tool_search_tool_regex_tool_result"
+	case "tool_search_tool_bm25":
+		return "tool_search_tool_bm25_tool_result"
+	default:
+		return "tool_result"
+	}
+}
+
+func resolveAnthropicProviderToolName(tools []provider.Tool, toolName string) string {
+	for _, tool := range tools {
+		if tool.Type != provider.ToolTypeProvider || tool.Name != toolName {
+			continue
+		}
+		switch tool.ID {
+		case "anthropic.web_search_20250305", "anthropic.web_search_20260209":
+			return "web_search"
+		case "anthropic.web_fetch_20250910", "anthropic.web_fetch_20260209":
+			return "web_fetch"
+		case "anthropic.code_execution_20250522", "anthropic.code_execution_20250825", "anthropic.code_execution_20260120":
+			return "code_execution"
+		case "anthropic.tool_search_bm25_20251119":
+			return "tool_search_tool_bm25"
+		case "anthropic.tool_search_regex_20251119":
+			return "tool_search_tool_regex"
+		}
+	}
+	return ""
+}
+
+func anthropicTypeFromOptions(opts provider.ProviderOptions) string {
+	raw, ok := readAnthropicRaw(opts)
+	if !ok {
+		return ""
+	}
+	return anthropicTypeFromRaw(raw)
+}
+
+func anthropicTypeFromMetadata(metadata provider.ProviderMetadata) string {
+	return anthropicTypeFromRaw(metadata["anthropic"])
+}
+
+func anthropicTypeFromRaw(raw json.RawMessage) string {
+	var value struct {
+		Type string `json:"type"`
+	}
+	if len(raw) == 0 || json.Unmarshal(raw, &value) != nil {
+		return ""
+	}
+	return value.Type
 }
 
 // toolResultContent serializes a provider.ToolResultOutput into the JSON form
@@ -237,8 +354,8 @@ func normalizeJSONObject(in json.RawMessage) json.RawMessage {
 	if len(in) == 0 {
 		return nil
 	}
-	var v any
-	if err := json.Unmarshal(in, &v); err != nil {
+	v, ok := decodeJSONValue(in)
+	if !ok {
 		return cloneRawJSON(in)
 	}
 	out, err := json.Marshal(v)
@@ -246,6 +363,74 @@ func normalizeJSONObject(in json.RawMessage) json.RawMessage {
 		return cloneRawJSON(in)
 	}
 	return out
+}
+
+func decodeJSONValue(in json.RawMessage) (any, bool) {
+	if !json.Valid(in) {
+		return nil, false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(in))
+	decoder.UseNumber()
+	value, ok := decodeJSONToken(decoder)
+	if !ok {
+		return nil, false
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return nil, false
+	}
+	return value, true
+}
+
+func decodeJSONToken(decoder *json.Decoder) (any, bool) {
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, false
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return token, true
+	}
+	switch delimiter {
+	case '{':
+		object := map[string]any{}
+		for decoder.More() {
+			key, err := decoder.Token()
+			if err != nil {
+				return nil, false
+			}
+			name, ok := key.(string)
+			if !ok {
+				return nil, false
+			}
+			if _, duplicate := object[name]; duplicate {
+				return nil, false
+			}
+			value, ok := decodeJSONToken(decoder)
+			if !ok {
+				return nil, false
+			}
+			object[name] = value
+		}
+		if end, err := decoder.Token(); err != nil || end != json.Delim('}') {
+			return nil, false
+		}
+		return object, true
+	case '[':
+		array := []any{}
+		for decoder.More() {
+			value, ok := decodeJSONToken(decoder)
+			if !ok {
+				return nil, false
+			}
+			array = append(array, value)
+		}
+		if end, err := decoder.Token(); err != nil || end != json.Delim(']') {
+			return nil, false
+		}
+		return array, true
+	default:
+		return nil, false
+	}
 }
 
 // toolsToAgento11y converts ai-sdk Tool definitions to agento11y.ToolDefinition.

--- a/middleware/agentobservability/map_request_test.go
+++ b/middleware/agentobservability/map_request_test.go
@@ -45,6 +45,18 @@ func TestMessagesToAgento11y_AssistantWithReasoning(t *testing.T) {
 	assert.Equal(t, agento11y.PartKindText, msgs[0].Parts[1].Kind)
 }
 
+func TestMessagesToAgento11y_SkipsEmptyReasoning(t *testing.T) {
+	prompt := []provider.Message{provider.NewAssistantMessage(
+		provider.ReasoningPart(""),
+		provider.TextPart("answer"),
+	)}
+
+	_, msgs := messagesToAgento11y(prompt)
+	require.Len(t, msgs, 1)
+	require.Len(t, msgs[0].Parts, 1)
+	assert.Equal(t, agento11y.PartKindText, msgs[0].Parts[0].Kind)
+}
+
 func TestMessagesToAgento11y_ToolResultSplitting(t *testing.T) {
 	// A user message that mixes a text part and a tool_result part should be
 	// split: the text part lands in a RoleUser agento11y.Message; the tool_result
@@ -162,6 +174,122 @@ func TestMessagesToAgento11y_AssistantServerToolCall(t *testing.T) {
 	require.Len(t, msgs, 1)
 	require.Len(t, msgs[0].Parts, 1)
 	assert.Equal(t, "server_tool_use", msgs[0].Parts[0].Metadata.ProviderType)
+}
+
+func TestMessagesToAgento11y_AssistantProviderToolDiscriminators(t *testing.T) {
+	tests := []struct {
+		name string
+		part provider.ContentPart
+		want string
+	}{
+		{
+			name: "tool search",
+			part: provider.ContentPart{Type: provider.ContentPartTypeToolCall, ToolName: "tool_search_tool_bm25", ProviderExecuted: true},
+			want: "tool_search_tool_bm25",
+		},
+		{
+			name: "mcp",
+			part: provider.ContentPart{
+				Type:     provider.ContentPartTypeToolCall,
+				ToolName: "remote_lookup",
+				ProviderOptions: provider.ProviderOptions{
+					"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"type":"mcp-tool-use"}`)},
+				},
+			},
+			want: "mcp_tool_use",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, providerTypeForToolCall(tc.part))
+		})
+	}
+}
+
+func TestResolveAnthropicProviderToolName_RequiresExactSupportedID(t *testing.T) {
+	tests := []struct {
+		id   string
+		want string
+	}{
+		{id: "anthropic.web_search_20250305", want: "web_search"},
+		{id: "anthropic.web_search_20260209", want: "web_search"},
+		{id: "anthropic.web_fetch_20250910", want: "web_fetch"},
+		{id: "anthropic.web_fetch_20260209", want: "web_fetch"},
+		{id: "anthropic.code_execution_20250522", want: "code_execution"},
+		{id: "anthropic.code_execution_20250825", want: "code_execution"},
+		{id: "anthropic.code_execution_20260120", want: "code_execution"},
+		{id: "anthropic.tool_search_bm25_20251119", want: "tool_search_tool_bm25"},
+		{id: "anthropic.tool_search_regex_20251119", want: "tool_search_tool_regex"},
+		{id: "anthropic.web_search_not-real"},
+		{id: "anthropic.web_fetch_"},
+		{id: "anthropic.code_execution_99999999"},
+		{id: "anthropic.tool_search_bm25_20251119_extra"},
+		{id: "anthropic.tool_search_regex_20251118"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.id, func(t *testing.T) {
+			got := resolveAnthropicProviderToolName([]provider.Tool{{
+				Type: provider.ToolTypeProvider, ID: tc.id, Name: "alias",
+			}}, "alias")
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMessagesToAgento11y_ProviderToolAliases(t *testing.T) {
+	tools := []provider.Tool{{
+		Type: provider.ToolTypeProvider,
+		ID:   "anthropic.tool_search_regex_20251119",
+		Name: "find_tools",
+	}}
+	call := provider.ToolCallPart("call-1", "find_tools", json.RawMessage(`{}`))
+	call.ProviderExecuted = true
+	result := provider.ContentPart{
+		Type:       provider.ContentPartTypeToolResult,
+		ToolCallID: "call-1",
+		ToolName:   "find_tools",
+		Output:     &provider.ToolResultOutput{Type: provider.ToolOutputJSON, JSON: json.RawMessage(`[]`)},
+	}
+
+	_, messages := messagesToAgento11yWithTools(
+		[]provider.Message{provider.NewAssistantMessage(call), provider.NewToolMessage(result)},
+		tools,
+	)
+	require.Len(t, messages, 2)
+	assert.Equal(t, "tool_search_tool_regex", messages[0].Parts[0].Metadata.ProviderType)
+	assert.Equal(t, "tool_search_tool_regex_tool_result", messages[1].Parts[0].Metadata.ProviderType)
+}
+
+func TestMessagesToAgento11y_CodeExecutionResultDiscriminators(t *testing.T) {
+	tools := []provider.Tool{{
+		Type: provider.ToolTypeProvider, ID: "anthropic.code_execution_20250825", Name: "run_code",
+	}}
+	tests := []struct {
+		name             string
+		result           string
+		providerExecuted bool
+		want             string
+	}{
+		{name: "code execution", result: `{"type":"code_execution_result"}`, providerExecuted: true, want: "code_execution_tool_result"},
+		{name: "bash after response-to-prompt conversion", result: `{"type":"bash_code_execution_result"}`, want: "bash_code_execution_tool_result"},
+		{name: "text editor", result: `{"type":"text_editor_code_execution_create_result"}`, providerExecuted: true, want: "text_editor_code_execution_tool_result"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			part := provider.ContentPart{
+				Type: provider.ContentPartTypeToolResult, ToolCallID: "call-1", ToolName: "run_code",
+				ProviderExecuted: tc.providerExecuted,
+				Output:           &provider.ToolResultOutput{Type: provider.ToolOutputJSON, JSON: json.RawMessage(tc.result)},
+			}
+			_, messages := messagesToAgento11yWithTools(
+				[]provider.Message{provider.NewToolMessage(part)}, tools,
+			)
+			require.Len(t, messages, 1)
+			assert.Equal(t, tc.want, messages[0].Parts[0].Metadata.ProviderType)
+		})
+	}
 }
 
 func TestToolsToAgento11y(t *testing.T) {

--- a/middleware/agentobservability/map_response.go
+++ b/middleware/agentobservability/map_response.go
@@ -19,14 +19,18 @@ const (
 	stopReasonOther        = "other"
 )
 
-// contentToAgento11yOutput converts a generate result's content slice into the
-// single assistant-role agento11y.Message recorded as Generation.Output.
+// contentToAgento11yOutput converts generated content into an assistant message
+// plus tool-role messages for tool results.
 //
 // Mirrors `agento11y/go-providers/anthropic.mapResponseMessages` modulo the
 // tool-result splitting (we do the same split into a separate RoleTool
 // message when the response carries tool-result parts; that path is rare for
 // generate responses but valid for provider-executed multi-turn).
 func contentToAgento11yOutput(content []provider.GenerateContentPart) []agento11y.Message {
+	return contentToAgento11yOutputWithTools(content, nil)
+}
+
+func contentToAgento11yOutputWithTools(content []provider.GenerateContentPart, tools []provider.Tool) []agento11y.Message {
 	if len(content) == 0 {
 		return nil
 	}
@@ -35,7 +39,7 @@ func contentToAgento11yOutput(content []provider.GenerateContentPart) []agento11
 	toolParts := make([]agento11y.Part, 0, 1)
 
 	for i := range content {
-		part, kind, ok := generateContentPartToAgento11y(content[i])
+		part, kind, ok := generateContentPartToAgento11yWithTools(content[i], tools)
 		if !ok {
 			continue
 		}
@@ -65,7 +69,7 @@ func contentToAgento11yOutput(content []provider.GenerateContentPart) []agento11
 	return out
 }
 
-func generateContentPartToAgento11y(part provider.GenerateContentPart) (agento11y.Part, agento11y.PartKind, bool) {
+func generateContentPartToAgento11yWithTools(part provider.GenerateContentPart, tools []provider.Tool) (agento11y.Part, agento11y.PartKind, bool) {
 	switch part.Type {
 	case provider.ContentText:
 		if part.Text == "" {
@@ -74,6 +78,9 @@ func generateContentPartToAgento11y(part provider.GenerateContentPart) (agento11
 		return agento11y.TextPart(part.Text), agento11y.PartKindText, true
 
 	case provider.ContentReasoning:
+		if part.Text == "" {
+			return agento11y.Part{}, "", false
+		}
 		out := agento11y.ThinkingPart(part.Text)
 		out.Metadata.ProviderType = "thinking"
 		return out, agento11y.PartKindThinking, true
@@ -85,7 +92,7 @@ func generateContentPartToAgento11y(part provider.GenerateContentPart) (agento11
 			InputJSON: normalizeJSONObject(part.Input),
 		}
 		out := agento11y.ToolCallPart(call)
-		out.Metadata.ProviderType = providerTypeForGenerateToolCall(part)
+		out.Metadata.ProviderType = providerTypeForGenerateToolCall(part, tools)
 		return out, agento11y.PartKindToolCall, true
 
 	case provider.ContentToolResult:
@@ -100,7 +107,13 @@ func generateContentPartToAgento11y(part provider.GenerateContentPart) (agento11
 			IsError:     isErr,
 			ContentJSON: contentJSON,
 		})
-		out.Metadata.ProviderType = "tool_result"
+		out.Metadata.ProviderType = providerTypeForToolResult(
+			part.ProviderExecuted,
+			part.ToolName,
+			anthropicTypeFromMetadata(part.ProviderMetadata),
+			tools,
+			contentJSON,
+		)
 		return out, agento11y.PartKindToolResult, true
 
 	case provider.ContentFile:
@@ -123,11 +136,13 @@ func generateContentPartToAgento11y(part provider.GenerateContentPart) (agento11
 	}
 }
 
-func providerTypeForGenerateToolCall(part provider.GenerateContentPart) string {
-	if part.ProviderExecuted {
-		return "server_tool_use"
-	}
-	return "tool_use"
+func providerTypeForGenerateToolCall(part provider.GenerateContentPart, tools []provider.Tool) string {
+	return providerTypeForToolWithDefinitions(
+		part.ProviderExecuted,
+		part.ToolName,
+		anthropicTypeFromMetadata(part.ProviderMetadata),
+		tools,
+	)
 }
 
 // usageToAgento11y converts provider.Usage into agento11y.TokenUsage. The mapping

--- a/middleware/agentobservability/map_response_test.go
+++ b/middleware/agentobservability/map_response_test.go
@@ -44,6 +44,17 @@ func TestContentToAgento11yOutput_Reasoning(t *testing.T) {
 	assert.Equal(t, "thinking", msgs[0].Parts[0].Metadata.ProviderType)
 }
 
+func TestContentToAgento11yOutput_SkipsEmptyReasoning(t *testing.T) {
+	msgs := contentToAgento11yOutput([]provider.GenerateContentPart{
+		{Type: provider.ContentReasoning},
+		{Type: provider.ContentText, Text: "answer"},
+	})
+
+	require.Len(t, msgs, 1)
+	require.Len(t, msgs[0].Parts, 1)
+	assert.Equal(t, agento11y.PartKindText, msgs[0].Parts[0].Kind)
+}
+
 func TestContentToAgento11yOutput_ToolResultSplit(t *testing.T) {
 	content := []provider.GenerateContentPart{
 		{Type: provider.ContentText, Text: "Looking that up…"},
@@ -58,6 +69,19 @@ func TestContentToAgento11yOutput_ToolResultSplit(t *testing.T) {
 	require.Len(t, msgs, 2, "assistant + tool message split")
 	assert.Equal(t, agento11y.RoleAssistant, msgs[0].Role)
 	assert.Equal(t, agento11y.RoleTool, msgs[1].Role)
+}
+
+func TestContentToAgento11yOutput_CodeExecutionResultSubtype(t *testing.T) {
+	tools := []provider.Tool{{
+		Type: provider.ToolTypeProvider, ID: "anthropic.code_execution_20250825", Name: "run_code",
+	}}
+	messages := contentToAgento11yOutputWithTools([]provider.GenerateContentPart{{
+		Type: provider.ContentToolResult, ToolCallID: "call-1", ToolName: "run_code",
+		ProviderExecuted: true,
+		Result:           json.RawMessage(`{"type":"bash_code_execution_result"}`),
+	}}, tools)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "bash_code_execution_tool_result", messages[0].Parts[0].Metadata.ProviderType)
 }
 
 func TestContentToAgento11yOutput_FileParts(t *testing.T) {
@@ -238,6 +262,87 @@ func TestUsageToAgento11y(t *testing.T) {
 func TestUsageToAgento11y_Zero(t *testing.T) {
 	got := usageToAgento11y(provider.Usage{})
 	assert.Equal(t, agento11y.TokenUsage{}, got)
+}
+
+func TestMetadataFromUsage_ServerToolUse(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want map[string]any
+	}{
+		{
+			name: "search and fetch",
+			raw:  `{"server_tool_use":{"web_search_requests":2,"web_fetch_requests":1}}`,
+			want: map[string]any{
+				MetadataServerToolUseWebSearchRequests: int64(2),
+				MetadataServerToolUseWebFetchRequests:  int64(1),
+				MetadataServerToolUseTotalRequests:     int64(3),
+			},
+		},
+		{
+			name: "search only",
+			raw:  `{"server_tool_use":{"web_search_requests":1}}`,
+			want: map[string]any{
+				MetadataServerToolUseWebSearchRequests: int64(1),
+				MetadataServerToolUseTotalRequests:     int64(1),
+			},
+		},
+		{name: "zero", raw: `{"server_tool_use":{"web_search_requests":0}}`},
+		{name: "negative", raw: `{"server_tool_use":{"web_search_requests":-1}}`},
+		{name: "malformed", raw: `{`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := metadataFromUsage(provider.Usage{Raw: json.RawMessage(tc.raw)})
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestProviderTypeForGenerateToolCall(t *testing.T) {
+	tests := []struct {
+		name string
+		part provider.GenerateContentPart
+		want string
+	}{
+		{name: "client tool", part: provider.GenerateContentPart{ToolName: "lookup"}, want: "tool_use"},
+		{name: "server tool", part: provider.GenerateContentPart{ToolName: "web_search", ProviderExecuted: true}, want: "server_tool_use"},
+		{name: "tool search", part: provider.GenerateContentPart{ToolName: "tool_search_tool_bm25", ProviderExecuted: true}, want: "tool_search_tool_bm25"},
+		{
+			name: "mcp",
+			part: provider.GenerateContentPart{
+				ToolName:         "remote_lookup",
+				ProviderExecuted: true,
+				ProviderMetadata: provider.ProviderMetadata{"anthropic": json.RawMessage(`{"type":"mcp-tool-use"}`)},
+			},
+			want: "mcp_tool_use",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, providerTypeForGenerateToolCall(tc.part, nil))
+		})
+	}
+}
+
+func TestContentToAgento11yOutput_ProviderToolAliases(t *testing.T) {
+	tools := []provider.Tool{
+		{Type: provider.ToolTypeProvider, ID: "anthropic.tool_search_bm25_20251119", Name: "find_tools"},
+		{Type: provider.ToolTypeProvider, ID: "anthropic.web_search_20250305", Name: "search_docs"},
+	}
+	msgs := contentToAgento11yOutputWithTools([]provider.GenerateContentPart{
+		{Type: provider.ContentToolCall, ToolCallID: "call-1", ToolName: "find_tools", ProviderExecuted: true},
+		{Type: provider.ContentToolResult, ToolCallID: "call-1", ToolName: "find_tools"},
+		{Type: provider.ContentToolResult, ToolCallID: "call-2", ToolName: "search_docs"},
+	}, tools)
+
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "tool_search_tool_bm25", msgs[0].Parts[0].Metadata.ProviderType)
+	require.Len(t, msgs[1].Parts, 2)
+	assert.Equal(t, "tool_search_tool_bm25_tool_result", msgs[1].Parts[0].Metadata.ProviderType)
+	assert.Equal(t, "web_search_tool_result", msgs[1].Parts[1].Metadata.ProviderType)
 }
 
 func TestFinishReasonToAgento11yStop(t *testing.T) {

--- a/middleware/agentobservability/map_stream.go
+++ b/middleware/agentobservability/map_stream.go
@@ -34,18 +34,21 @@ type StreamRecorder struct {
 	// Per-step accumulators. Streams may emit multiple text/reasoning blocks
 	// keyed by an ID (text-start / text-end frame them); we maintain a map so
 	// concurrent IDs accumulate correctly.
-	texts       map[string]*streamTextAcc
-	reasonings  map[string]*streamReasoningAcc
-	toolCalls   map[string]*streamToolCallAcc
-	mediaParts  []agento11y.Part
-	outputOrder []streamOutputRef
-	toolResults []streamToolResultAcc
+	texts                map[string]*streamTextAcc
+	reasonings           map[string]*streamTextAcc
+	toolCalls            []*streamToolCallAcc
+	activeToolCalls      map[string]int
+	mediaParts           []agento11y.Part
+	outputOrder          []streamOutputRef
+	toolResults          []streamToolResultAcc
+	toolResultByIdentity map[streamToolIdentity]int
 
 	// Aggregated stream state.
-	finishReason *provider.FinishReason
-	usage        streamusage.Aggregator
-	responseID   string
-	response     generationModelIdentity
+	finishReason  *provider.FinishReason
+	usage         streamusage.Aggregator
+	responseID    string
+	responseModel string
+	response      generationModelIdentity
 
 	// Error captured from a PartError event mid-stream. The middleware
 	// surfaces this through GenerationRecorder.SetCallError rather than
@@ -56,16 +59,17 @@ type StreamRecorder struct {
 type streamOutputRef struct {
 	partType   provider.StreamPartType
 	id         string
+	toolIndex  int
 	mediaIndex int
+}
+
+type streamToolIdentity struct {
+	id   string
+	name string
 }
 
 type streamTextAcc struct {
 	text strings.Builder
-}
-
-type streamReasoningAcc struct {
-	text      strings.Builder
-	signature string
 }
 
 type streamToolCallAcc struct {
@@ -73,16 +77,20 @@ type streamToolCallAcc struct {
 	name             string
 	input            strings.Builder
 	providerExecuted bool
+	anthropicType    string
 	// final captures the consolidated input when a PartToolCall event fires
 	// (some providers emit the complete input there rather than via deltas).
 	final json.RawMessage
 }
 
 type streamToolResultAcc struct {
-	id      string
-	name    string
-	result  json.RawMessage
-	isError bool
+	id               string
+	name             string
+	result           json.RawMessage
+	isError          bool
+	preliminary      bool
+	providerExecuted bool
+	anthropicType    string
 }
 
 // NewStreamRecorder constructs a StreamRecorder seeded with the
@@ -90,11 +98,12 @@ type streamToolResultAcc struct {
 // folded into Generation() at end-of-stream alongside the accumulated output.
 func NewStreamRecorder(start agento11y.GenerationStart, params provider.CallOptions) *StreamRecorder {
 	return &StreamRecorder{
-		seed:       start,
-		params:     params,
-		texts:      map[string]*streamTextAcc{},
-		reasonings: map[string]*streamReasoningAcc{},
-		toolCalls:  map[string]*streamToolCallAcc{},
+		seed:                 start,
+		params:               params,
+		texts:                map[string]*streamTextAcc{},
+		reasonings:           map[string]*streamTextAcc{},
+		activeToolCalls:      map[string]int{},
+		toolResultByIdentity: map[streamToolIdentity]int{},
 	}
 }
 
@@ -150,62 +159,48 @@ func (r *StreamRecorder) Observe(part provider.StreamPart) {
 
 	case provider.PartReasoningStart:
 		r.ensureReasoning(part.ID)
-		// Some Anthropic reasoning streams attach the signature on the start
-		// event rather than every delta.
-		if sig := anthropicSignatureFromMetadata(part.ProviderMetadata); sig != "" {
-			r.reasonings[part.ID].signature = sig
-		}
 
 	case provider.PartReasoningDelta:
 		acc := r.ensureReasoning(part.ID)
 		acc.text.WriteString(part.Delta)
-		if sig := anthropicSignatureFromMetadata(part.ProviderMetadata); sig != "" {
-			// Multiple deltas may carry the same signature value; we merge
-			// to a single copy on the consolidated reasoning part.
-			acc.signature = sig
-		}
-
-	case provider.PartReasoningEnd:
-		if sig := anthropicSignatureFromMetadata(part.ProviderMetadata); sig != "" {
-			if acc, ok := r.reasonings[part.ID]; ok {
-				acc.signature = sig
-			}
-		}
 
 	case provider.PartToolInputStart:
-		acc := r.ensureToolCall(streamToolCallID(part), part.ToolName)
+		acc := r.startToolCall(streamToolCallID(part), part.ToolName)
 		acc.providerExecuted = acc.providerExecuted || part.ProviderExecuted
+		if anthropicType := anthropicTypeFromMetadata(part.ProviderMetadata); anthropicType != "" {
+			acc.anthropicType = anthropicType
+		}
 
 	case provider.PartToolInputDelta:
-		acc := r.ensureToolCall(streamToolCallID(part), part.ToolName)
+		acc := r.currentToolCall(streamToolCallID(part), part.ToolName)
 		acc.input.WriteString(part.Delta)
 
 	case provider.PartToolInputEnd:
 		// Caller may still emit a PartToolCall with the consolidated input.
 
 	case provider.PartToolCall:
-		acc := r.ensureToolCall(streamToolCallID(part), part.ToolName)
+		acc := r.finishToolCall(streamToolCallID(part), part.ToolName)
 		acc.providerExecuted = acc.providerExecuted || part.ProviderExecuted
+		if anthropicType := anthropicTypeFromMetadata(part.ProviderMetadata); anthropicType != "" {
+			acc.anthropicType = anthropicType
+		}
 		if part.Input != "" {
 			acc.final = json.RawMessage(part.Input)
 		}
 
 	case provider.PartToolResult:
-		r.toolResults = append(r.toolResults, streamToolResultAcc{
-			id:      part.ToolCallID,
-			name:    part.ToolName,
-			result:  part.Result,
-			isError: part.IsError,
-		})
+		r.observeToolResult(part)
 
 	case provider.PartFile:
 		if media, ok := streamFilePartToAgento11y(part, "file"); ok {
+			r.markFirstChunk()
 			r.outputOrder = append(r.outputOrder, streamOutputRef{partType: part.Type, mediaIndex: len(r.mediaParts)})
 			r.mediaParts = append(r.mediaParts, media)
 		}
 
 	case provider.PartReasoningFile:
 		if media, ok := streamFilePartToAgento11y(part, "reasoning_file"); ok {
+			r.markFirstChunk()
 			r.outputOrder = append(r.outputOrder, streamOutputRef{partType: part.Type, mediaIndex: len(r.mediaParts)})
 			r.mediaParts = append(r.mediaParts, media)
 		}
@@ -217,14 +212,64 @@ func (r *StreamRecorder) Observe(part provider.StreamPart) {
 		}
 
 	case provider.PartResponseMeta:
-		r.responseID = part.ResponseID
-		r.response = modelIdentityFromResponse(part.Provider, part.ModelID)
+		if part.ResponseID != "" {
+			r.responseID = part.ResponseID
+		}
+		if part.ModelID != "" {
+			r.responseModel = part.ModelID
+		}
+		if response := modelIdentityFromResponse(part.Provider, part.ModelID); response.complete() {
+			r.response = response
+		}
 
 	case provider.PartError:
 		if part.APICallError != nil {
 			r.callError = part.APICallError
 		}
 	}
+}
+
+func (r *StreamRecorder) markFirstChunk() {
+	if r.firstChunkAt.IsZero() {
+		r.firstChunkAt = time.Now().UTC()
+	}
+}
+
+func (r *StreamRecorder) observeToolResult(part provider.StreamPart) {
+	preliminary := part.Preliminary != nil && *part.Preliminary
+	result := streamToolResultAcc{
+		id:               part.ToolCallID,
+		name:             part.ToolName,
+		result:           cloneRawJSON(part.Result),
+		isError:          part.IsError,
+		preliminary:      preliminary,
+		providerExecuted: part.ProviderExecuted,
+		anthropicType:    anthropicTypeFromMetadata(part.ProviderMetadata),
+	}
+	if part.ToolCallID == "" {
+		r.toolResults = append(r.toolResults, result)
+		return
+	}
+	identity := streamToolIdentity{id: part.ToolCallID, name: part.ToolName}
+	if index, ok := r.toolResultByIdentity[identity]; ok {
+		previous := r.toolResults[index]
+		result.providerExecuted = result.providerExecuted || previous.providerExecuted
+		if result.name == "" {
+			result.name = previous.name
+		}
+		if result.anthropicType == "" {
+			result.anthropicType = previous.anthropicType
+		}
+		r.toolResults[index] = result
+		if !preliminary {
+			delete(r.toolResultByIdentity, identity)
+		}
+		return
+	}
+	if preliminary {
+		r.toolResultByIdentity[identity] = len(r.toolResults)
+	}
+	r.toolResults = append(r.toolResults, result)
 }
 
 func (r *StreamRecorder) ensureText(id string) *streamTextAcc {
@@ -237,11 +282,11 @@ func (r *StreamRecorder) ensureText(id string) *streamTextAcc {
 	return acc
 }
 
-func (r *StreamRecorder) ensureReasoning(id string) *streamReasoningAcc {
+func (r *StreamRecorder) ensureReasoning(id string) *streamTextAcc {
 	if acc, ok := r.reasonings[id]; ok {
 		return acc
 	}
-	acc := &streamReasoningAcc{}
+	acc := &streamTextAcc{}
 	r.reasonings[id] = acc
 	r.outputOrder = append(r.outputOrder, streamOutputRef{partType: provider.PartReasoningStart, id: id})
 	return acc
@@ -257,16 +302,44 @@ func streamToolCallID(part provider.StreamPart) string {
 	return part.ToolCallID
 }
 
-func (r *StreamRecorder) ensureToolCall(id, name string) *streamToolCallAcc {
-	if acc, ok := r.toolCalls[id]; ok {
+func (r *StreamRecorder) startToolCall(id, name string) *streamToolCallAcc {
+	acc := r.appendToolCall(id, name)
+	r.activeToolCalls[id] = len(r.toolCalls) - 1
+	return acc
+}
+
+func (r *StreamRecorder) currentToolCall(id, name string) *streamToolCallAcc {
+	if index, ok := r.activeToolCalls[id]; ok {
+		acc := r.toolCalls[index]
 		if acc.name == "" && name != "" {
 			acc.name = name
 		}
 		return acc
 	}
+	return r.startToolCall(id, name)
+}
+
+func (r *StreamRecorder) finishToolCall(id, name string) *streamToolCallAcc {
+	if index, ok := r.activeToolCalls[id]; ok {
+		delete(r.activeToolCalls, id)
+		acc := r.toolCalls[index]
+		if acc.name == "" || name == "" || acc.name == name {
+			if acc.name == "" {
+				acc.name = name
+			}
+			return acc
+		}
+	}
+	return r.appendToolCall(id, name)
+}
+
+func (r *StreamRecorder) appendToolCall(id, name string) *streamToolCallAcc {
 	acc := &streamToolCallAcc{id: id, name: name}
-	r.toolCalls[id] = acc
-	r.outputOrder = append(r.outputOrder, streamOutputRef{partType: provider.PartToolCall, id: id})
+	r.toolCalls = append(r.toolCalls, acc)
+	r.outputOrder = append(r.outputOrder, streamOutputRef{
+		partType:  provider.PartToolCall,
+		toolIndex: len(r.toolCalls) - 1,
+	})
 	return acc
 }
 
@@ -283,10 +356,15 @@ func (r *StreamRecorder) Generation() agento11y.Generation {
 
 	// Compose Generation from CallOptions identically to MapGenerateResult,
 	// using the accumulated output instead of result.Content.
-	system, input := messagesToAgento11y(r.params.Prompt)
+	system, input := messagesToAgento11yWithTools(r.params.Prompt, r.params.Tools)
 	controls := controlsFromCallOptions(r.params)
 
 	output := r.buildOutput()
+	usage, hasUsage := r.usage.Usage()
+	metadata := mergeMetadata(r.seed.Metadata, metadataFromProviderOptions(r.params))
+	if hasUsage {
+		metadata = mergeMetadata(metadata, metadataFromUsage(usage))
+	}
 
 	gen := agento11y.Generation{
 		UserID:              r.seed.UserID,
@@ -303,14 +381,18 @@ func (r *StreamRecorder) Generation() agento11y.Generation {
 		ToolChoice:          controls.ToolChoice,
 		ThinkingEnabled:     thinkingEnabledFromAnthropic(r.params.ProviderOptions),
 		Tags:                cloneStringMap(r.seed.Tags),
-		Metadata:            mergeMetadata(metadataFromProviderOptions(r.params), r.seed.Metadata),
+		Metadata:            metadata,
 	}
 	if r.responseID != "" {
 		gen.ResponseID = r.responseID
 	}
+	gen.ResponseModel = r.seed.Model.Name
+	if r.responseModel != "" {
+		gen.ResponseModel = r.responseModel
+	}
 	applyModelIdentity(&gen, modelIdentityFromStart(r.seed), r.response)
 
-	if usage, ok := r.usage.Usage(); ok {
+	if hasUsage {
 		gen.Usage = usageToAgento11y(usage)
 	}
 	if r.finishReason != nil {
@@ -329,7 +411,7 @@ func (r *StreamRecorder) buildOutput() []agento11y.Message {
 		switch ref.partType {
 		case provider.PartReasoningStart:
 			acc := r.reasonings[ref.id]
-			if acc.text.Len() == 0 && acc.signature == "" {
+			if acc.text.Len() == 0 {
 				continue
 			}
 			part := agento11y.ThinkingPart(acc.text.String())
@@ -344,7 +426,7 @@ func (r *StreamRecorder) buildOutput() []agento11y.Message {
 			parts = append(parts, agento11y.TextPart(acc.text.String()))
 
 		case provider.PartToolCall:
-			acc := r.toolCalls[ref.id]
+			acc := r.toolCalls[ref.toolIndex]
 			var input json.RawMessage
 			if len(acc.final) > 0 {
 				input = normalizeJSONObject(acc.final)
@@ -356,11 +438,12 @@ func (r *StreamRecorder) buildOutput() []agento11y.Message {
 				Name:      acc.name,
 				InputJSON: input,
 			})
-			if acc.providerExecuted {
-				part.Metadata.ProviderType = "server_tool_use"
-			} else {
-				part.Metadata.ProviderType = "tool_use"
-			}
+			part.Metadata.ProviderType = providerTypeForToolWithDefinitions(
+				acc.providerExecuted,
+				acc.name,
+				acc.anthropicType,
+				r.params.Tools,
+			)
 			parts = append(parts, part)
 
 		case provider.PartFile, provider.PartReasoningFile:
@@ -377,13 +460,30 @@ func (r *StreamRecorder) buildOutput() []agento11y.Message {
 	}
 
 	for _, result := range r.toolResults {
+		if result.preliminary {
+			continue
+		}
 		out := agento11y.ToolResultPart(agento11y.ToolResult{
 			ToolCallID:  result.id,
 			Name:        result.name,
 			IsError:     result.isError,
 			ContentJSON: result.result,
 		})
-		out.Metadata.ProviderType = "tool_result"
+		providerExecuted := result.providerExecuted
+		anthropicType := result.anthropicType
+		if call, ok := r.matchToolCall(result.id, result.name); ok {
+			providerExecuted = providerExecuted || call.providerExecuted
+			if anthropicType == "" {
+				anthropicType = call.anthropicType
+			}
+		}
+		out.Metadata.ProviderType = providerTypeForToolResult(
+			providerExecuted,
+			result.name,
+			anthropicType,
+			r.params.Tools,
+			result.result,
+		)
 		output = append(output, agento11y.Message{
 			Role:  agento11y.RoleTool,
 			Name:  result.name,
@@ -397,46 +497,29 @@ func (r *StreamRecorder) buildOutput() []agento11y.Message {
 	return output
 }
 
-// isPayloadPart returns true for stream events that represent observable
-// output (deltas, the final completion event, errors). Bookkeeping events
-// such as PartStreamStart or PartResponseMeta are excluded so first-token
-// timestamps reflect actual output emission.
+func (r *StreamRecorder) matchToolCall(id, name string) (*streamToolCallAcc, bool) {
+	var match *streamToolCallAcc
+	for _, call := range r.toolCalls {
+		if call.id != id || call.name != name {
+			continue
+		}
+		if match != nil {
+			return nil, false
+		}
+		match = call
+	}
+	return match, match != nil
+}
+
 func isPayloadPart(part provider.StreamPart) bool {
 	switch part.Type {
-	case provider.PartTextDelta,
-		provider.PartReasoningDelta,
-		provider.PartToolInputDelta,
-		provider.PartToolCall,
-		provider.PartToolResult,
-		provider.PartFile,
-		provider.PartReasoningFile,
-		provider.PartFinish,
-		provider.PartError:
+	case provider.PartTextDelta, provider.PartReasoningDelta, provider.PartToolInputDelta:
+		return part.Delta != ""
+	case provider.PartToolCall:
 		return true
 	default:
 		return false
 	}
-}
-
-// anthropicSignatureFromMetadata extracts the cryptographic signature
-// Anthropic attaches to reasoning blocks. The signature lives at
-// metadata["anthropic"].signature in the provider wire form; consumers must
-// preserve it byte-for-byte across recording roundtrips.
-func anthropicSignatureFromMetadata(meta provider.ProviderMetadata) string {
-	if len(meta) == 0 {
-		return ""
-	}
-	raw, ok := meta["anthropic"]
-	if !ok || len(raw) == 0 {
-		return ""
-	}
-	var probe struct {
-		Signature string `json:"signature"`
-	}
-	if err := json.Unmarshal(raw, &probe); err != nil {
-		return ""
-	}
-	return probe.Signature
 }
 
 func cloneStringSlice(in []string) []string {

--- a/middleware/agentobservability/map_stream_test.go
+++ b/middleware/agentobservability/map_stream_test.go
@@ -76,6 +76,38 @@ func TestStreamRecorder_UsageAggregatesEveryPart(t *testing.T) {
 	assert.Equal(t, int64(outputReasoning), usage.ReasoningTokens)
 }
 
+func TestStreamRecorder_ServerToolUsageMetadata(t *testing.T) {
+	r := newRecorderForStreamTest()
+	r.Observe(provider.StreamPart{Type: provider.PartFinish, Usage: &provider.Usage{
+		Raw: json.RawMessage(`{"server_tool_use":{"web_search_requests":1,"web_fetch_requests":2}}`),
+	}})
+
+	gen := r.Generation()
+	assert.Equal(t, int64(1), gen.Metadata[MetadataServerToolUseWebSearchRequests])
+	assert.Equal(t, int64(2), gen.Metadata[MetadataServerToolUseWebFetchRequests])
+	assert.Equal(t, int64(3), gen.Metadata[MetadataServerToolUseTotalRequests])
+}
+
+func TestStreamRecorder_ServerToolUsageMetadataOverridesSeed(t *testing.T) {
+	r := NewStreamRecorder(agento11y.GenerationStart{
+		Metadata: map[string]any{
+			MetadataServerToolUseWebSearchRequests: "caller search",
+			MetadataServerToolUseWebFetchRequests:  "caller fetch",
+			MetadataServerToolUseTotalRequests:     "caller total",
+			"caller.key":                           "preserved",
+		},
+	}, provider.CallOptions{})
+	r.Observe(provider.StreamPart{Type: provider.PartFinish, Usage: &provider.Usage{
+		Raw: json.RawMessage(`{"server_tool_use":{"web_search_requests":1,"web_fetch_requests":2}}`),
+	}})
+
+	gen := r.Generation()
+	assert.Equal(t, int64(1), gen.Metadata[MetadataServerToolUseWebSearchRequests])
+	assert.Equal(t, int64(2), gen.Metadata[MetadataServerToolUseWebFetchRequests])
+	assert.Equal(t, int64(3), gen.Metadata[MetadataServerToolUseTotalRequests])
+	assert.Equal(t, "preserved", gen.Metadata["caller.key"])
+}
+
 func TestStreamRecorder_FilePartsPreserveObservedOrder(t *testing.T) {
 	r := newRecorderForStreamTest()
 	r.Observe(provider.StreamPart{
@@ -119,27 +151,11 @@ func TestStreamRecorder_FilePartsPreserveObservedOrder(t *testing.T) {
 	assert.Equal(t, "reasoning_file", gen.Output[0].Parts[4].Metadata.ProviderType)
 }
 
-func TestStreamRecorder_TextReasoningSignature(t *testing.T) {
+func TestStreamRecorder_TextAndReasoning(t *testing.T) {
 	r := newRecorderForStreamTest()
 	r.Observe(provider.StreamPart{Type: provider.PartReasoningStart, ID: "r0"})
 	r.Observe(provider.StreamPart{Type: provider.PartReasoningDelta, ID: "r0", Delta: "let me "})
-	// Signature on later deltas — should be merged into the consolidated reasoning part.
-	r.Observe(provider.StreamPart{
-		Type:  provider.PartReasoningDelta,
-		ID:    "r0",
-		Delta: "think",
-		ProviderMetadata: provider.ProviderMetadata{
-			"anthropic": json.RawMessage(`{"signature":"sig-abc"}`),
-		},
-	})
-	r.Observe(provider.StreamPart{
-		Type: provider.PartReasoningDelta,
-		ID:   "r0",
-		// Same signature again — recorder dedupes to one copy.
-		ProviderMetadata: provider.ProviderMetadata{
-			"anthropic": json.RawMessage(`{"signature":"sig-abc"}`),
-		},
-	})
+	r.Observe(provider.StreamPart{Type: provider.PartReasoningDelta, ID: "r0", Delta: "think"})
 	r.Observe(provider.StreamPart{Type: provider.PartReasoningEnd, ID: "r0"})
 	r.Observe(provider.StreamPart{Type: provider.PartTextStart, ID: "t0"})
 	r.Observe(provider.StreamPart{Type: provider.PartTextDelta, ID: "t0", Delta: "answer"})
@@ -155,6 +171,25 @@ func TestStreamRecorder_TextReasoningSignature(t *testing.T) {
 	text := gen.Output[0].Parts[1]
 	assert.Equal(t, agento11y.PartKindText, text.Kind)
 	assert.Equal(t, "answer", text.Text)
+}
+
+func TestStreamRecorder_SkipsSignatureOnlyReasoning(t *testing.T) {
+	r := newRecorderForStreamTest()
+	r.Observe(provider.StreamPart{Type: provider.PartReasoningStart, ID: "r0"})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartReasoningDelta,
+		ID:   "r0",
+		ProviderMetadata: provider.ProviderMetadata{
+			"anthropic": json.RawMessage(`{"signature":"sig-abc"}`),
+		},
+	})
+	r.Observe(provider.StreamPart{Type: provider.PartReasoningEnd, ID: "r0"})
+	r.Observe(provider.StreamPart{Type: provider.PartTextDelta, ID: "t0", Delta: "answer"})
+
+	gen := r.Generation()
+	require.Len(t, gen.Output, 1)
+	require.Len(t, gen.Output[0].Parts, 1)
+	assert.Equal(t, agento11y.PartKindText, gen.Output[0].Parts[0].Kind)
 }
 
 func TestStreamRecorder_ToolCallDeltas(t *testing.T) {
@@ -203,6 +238,124 @@ func TestStreamRecorder_ProviderExecutedToolCall(t *testing.T) {
 	assert.Equal(t, "server_tool_use", call.Metadata.ProviderType)
 }
 
+func TestStreamRecorder_ProviderExecutedToolDiscriminators(t *testing.T) {
+	tests := []struct {
+		name string
+		part provider.StreamPart
+		want string
+	}{
+		{
+			name: "tool search",
+			part: provider.StreamPart{Type: provider.PartToolCall, ToolCallID: "tc-1", ToolName: "tool_search_tool_regex", ProviderExecuted: true},
+			want: "tool_search_tool_regex",
+		},
+		{
+			name: "mcp",
+			part: provider.StreamPart{
+				Type:             provider.PartToolCall,
+				ToolCallID:       "tc-1",
+				ToolName:         "remote_lookup",
+				ProviderExecuted: true,
+				ProviderMetadata: provider.ProviderMetadata{"anthropic": json.RawMessage(`{"type":"mcp-tool-use"}`)},
+			},
+			want: "mcp_tool_use",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newRecorderForStreamTest()
+			r.Observe(tc.part)
+			gen := r.Generation()
+			require.Len(t, gen.Output, 1)
+			require.Len(t, gen.Output[0].Parts, 1)
+			assert.Equal(t, tc.want, gen.Output[0].Parts[0].Metadata.ProviderType)
+		})
+	}
+}
+
+func TestStreamRecorder_ClonesToolProviderMetadata(t *testing.T) {
+	metadata := provider.ProviderMetadata{
+		"anthropic": json.RawMessage(`{"type":"mcp-tool-use"}`),
+	}
+	r := newRecorderForStreamTest()
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolCall, ToolCallID: "call-1", ToolName: "remote", ProviderExecuted: true,
+		ProviderMetadata: metadata,
+	})
+	metadata["anthropic"] = json.RawMessage(`{"type":"other"}`)
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolCall, ToolCallID: "call-1", ToolName: "remote", ProviderExecuted: true,
+		ProviderMetadata: provider.ProviderMetadata{"anthropic": json.RawMessage(`{"serverName":"remote"}`)},
+	})
+
+	gen := r.Generation()
+	require.Len(t, gen.Output, 1)
+	assert.Equal(t, "mcp_tool_use", gen.Output[0].Parts[0].Metadata.ProviderType)
+}
+
+func TestStreamRecorder_ToolMetadataRequiresExactInvocationIdentity(t *testing.T) {
+	r := newRecorderForStreamTest()
+	mcpMetadata := provider.ProviderMetadata{
+		"anthropic": json.RawMessage(`{"type":"mcp-tool-use"}`),
+	}
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolCall, ToolCallID: "same", ToolName: "remote", Input: `{"step":1}`,
+		ProviderMetadata: mcpMetadata,
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolInputStart, ID: "same", ToolName: "lookup",
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolInputDelta, ID: "same", Delta: `{"step":2}`,
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolCall, ToolCallID: "same", ToolName: "lookup", Input: `{"step":2}`,
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolResult, ToolCallID: "same", ToolName: "lookup", Result: json.RawMessage(`{"ok":true}`),
+	})
+
+	gen := r.Generation()
+	require.Len(t, gen.Output, 2)
+	require.Len(t, gen.Output[0].Parts, 2)
+	assert.Equal(t, "remote", gen.Output[0].Parts[0].ToolCall.Name)
+	assert.JSONEq(t, `{"step":1}`, string(gen.Output[0].Parts[0].ToolCall.InputJSON))
+	assert.Equal(t, "mcp_tool_use", gen.Output[0].Parts[0].Metadata.ProviderType)
+	assert.Equal(t, "lookup", gen.Output[0].Parts[1].ToolCall.Name)
+	assert.JSONEq(t, `{"step":2}`, string(gen.Output[0].Parts[1].ToolCall.InputJSON))
+	assert.Equal(t, "tool_use", gen.Output[0].Parts[1].Metadata.ProviderType)
+	assert.Equal(t, "tool_result", gen.Output[1].Parts[0].Metadata.ProviderType)
+}
+
+func TestStreamRecorder_ProviderToolAliasDiscriminators(t *testing.T) {
+	r := NewStreamRecorder(agento11y.GenerationStart{}, provider.CallOptions{Tools: []provider.Tool{
+		{Type: provider.ToolTypeProvider, ID: "anthropic.tool_search_regex_20251119", Name: "find_tools"},
+		{Type: provider.ToolTypeProvider, ID: "anthropic.web_fetch_20250910", Name: "fetch_page"},
+		{Type: provider.ToolTypeProvider, ID: "anthropic.code_execution_20250825", Name: "run_code"},
+	}})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolCall, ToolCallID: "call-1", ToolName: "find_tools", ProviderExecuted: true,
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolResult, ToolCallID: "call-1", ToolName: "find_tools",
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolResult, ToolCallID: "call-2", ToolName: "fetch_page",
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolResult, ToolCallID: "call-3", ToolName: "run_code", ProviderExecuted: true,
+		Result: json.RawMessage(`{"type":"text_editor_code_execution_create_result"}`),
+	})
+
+	gen := r.Generation()
+	require.Len(t, gen.Output, 4)
+	assert.Equal(t, "tool_search_tool_regex", gen.Output[0].Parts[0].Metadata.ProviderType)
+	assert.Equal(t, "tool_search_tool_regex_tool_result", gen.Output[1].Parts[0].Metadata.ProviderType)
+	assert.Equal(t, "web_fetch_tool_result", gen.Output[2].Parts[0].Metadata.ProviderType)
+	assert.Equal(t, "text_editor_code_execution_tool_result", gen.Output[3].Parts[0].Metadata.ProviderType)
+}
+
 func TestStreamRecorder_ToolResult(t *testing.T) {
 	r := newRecorderForStreamTest()
 	r.Observe(provider.StreamPart{
@@ -226,6 +379,47 @@ func TestStreamRecorder_ToolResult(t *testing.T) {
 	assert.JSONEq(t, `"sunny"`, string(result.ToolResult.ContentJSON))
 }
 
+func TestStreamRecorder_ToolResult_CoalescesPreliminaryResults(t *testing.T) {
+	r := newRecorderForStreamTest()
+	preliminary := true
+	r.Observe(provider.StreamPart{
+		Type:        provider.PartToolResult,
+		ToolCallID:  "tc-1",
+		ToolName:    "generate_image",
+		Result:      json.RawMessage(`{"url":"preview"}`),
+		Preliminary: &preliminary,
+	})
+	assert.Nil(t, r.Generation().Output)
+
+	r.Observe(provider.StreamPart{
+		Type:       provider.PartToolResult,
+		ToolCallID: "tc-1",
+		ToolName:   "generate_image",
+		Result:     json.RawMessage(`{"url":"final"}`),
+	})
+	gen := r.Generation()
+	require.Len(t, gen.Output, 1)
+	require.Len(t, gen.Output[0].Parts, 1)
+	assert.JSONEq(t, `{"url":"final"}`, string(gen.Output[0].Parts[0].ToolResult.ContentJSON))
+}
+
+func TestStreamRecorder_ToolResult_PreservesRepeatedFinalResults(t *testing.T) {
+	r := newRecorderForStreamTest()
+	for _, result := range []string{`{"step":1}`, `{"step":2}`} {
+		r.Observe(provider.StreamPart{
+			Type:       provider.PartToolResult,
+			ToolCallID: "tc-1",
+			ToolName:   "lookup",
+			Result:     json.RawMessage(result),
+		})
+	}
+
+	gen := r.Generation()
+	require.Len(t, gen.Output, 2)
+	assert.JSONEq(t, `{"step":1}`, string(gen.Output[0].Parts[0].ToolResult.ContentJSON))
+	assert.JSONEq(t, `{"step":2}`, string(gen.Output[1].Parts[0].ToolResult.ContentJSON))
+}
+
 func TestStreamRecorder_ToolCallFinalEvent(t *testing.T) {
 	// Some providers send PartToolCall with the consolidated Input instead of
 	// per-delta accumulation.
@@ -243,14 +437,41 @@ func TestStreamRecorder_ToolCallFinalEvent(t *testing.T) {
 }
 
 func TestStreamRecorder_FirstChunkAt(t *testing.T) {
-	r := newRecorderForStreamTest()
-	assert.True(t, r.FirstChunkAt().IsZero(), "no observations yet")
+	nonPayload := []provider.StreamPart{
+		{Type: provider.PartStreamStart},
+		{Type: provider.PartResponseMeta},
+		{Type: provider.PartTextDelta},
+		{Type: provider.PartToolResult},
+		{Type: provider.PartFile},
+		{Type: provider.PartReasoningFile},
+		{Type: provider.PartFinish},
+		{Type: provider.PartError},
+	}
+	for _, part := range nonPayload {
+		r := newRecorderForStreamTest()
+		r.Observe(part)
+		assert.True(t, r.FirstChunkAt().IsZero(), "%s must not start the clock", part.Type)
+	}
 
-	r.Observe(provider.StreamPart{Type: provider.PartStreamStart})
-	assert.True(t, r.FirstChunkAt().IsZero(), "bookkeeping events do not start the clock")
-
-	r.Observe(provider.StreamPart{Type: provider.PartTextDelta, ID: "t0", Delta: "x"})
-	assert.False(t, r.FirstChunkAt().IsZero(), "payload event starts the clock")
+	payload := []provider.StreamPart{
+		{Type: provider.PartTextDelta, Delta: "x"},
+		{Type: provider.PartReasoningDelta, Delta: "x"},
+		{Type: provider.PartToolInputDelta, Delta: "{"},
+		{Type: provider.PartToolCall},
+		{
+			Type: provider.PartFile, MediaType: "image/png",
+			Data: &provider.StreamFileData{URL: "https://example.com/image.png"},
+		},
+		{
+			Type: provider.PartReasoningFile, MediaType: "image/png",
+			Data: &provider.StreamFileData{URL: "https://example.com/reasoning.png"},
+		},
+	}
+	for _, part := range payload {
+		r := newRecorderForStreamTest()
+		r.Observe(part)
+		assert.False(t, r.FirstChunkAt().IsZero(), "%s must start the clock", part.Type)
+	}
 }
 
 func TestStreamRecorder_ErrorMidStream(t *testing.T) {
@@ -329,6 +550,14 @@ func TestStreamRecorder_ResponseMetadataModelIdentity(t *testing.T) {
 			wantProvider:     "anthropic",
 			wantModel:        "claude-sonnet-4-5-20250929",
 		},
+		{
+			name:             "missing response model uses request model",
+			seedProvider:     "anthropic",
+			seedModel:        "claude-sonnet-4-5-sonnet",
+			responseProvider: "anthropic",
+			wantProvider:     "anthropic",
+			wantModel:        "claude-sonnet-4-5-sonnet",
+		},
 	}
 
 	for _, tc := range tests {
@@ -348,6 +577,11 @@ func TestStreamRecorder_ResponseMetadataModelIdentity(t *testing.T) {
 			assert.Equal(t, tc.wantProvider, gen.Model.Provider)
 			assert.Equal(t, tc.wantModel, gen.Model.Name)
 			assert.Equal(t, "resp-1", gen.ResponseID)
+			wantResponseModel := tc.responseModel
+			if wantResponseModel == "" {
+				wantResponseModel = tc.seedModel
+			}
+			assert.Equal(t, wantResponseModel, gen.ResponseModel)
 			if tc.wantTransportMetadata {
 				require.NotNil(t, gen.Metadata)
 				assert.Equal(t, tc.seedProvider, gen.Metadata[transportProviderMetadataKey])
@@ -360,41 +594,43 @@ func TestStreamRecorder_ResponseMetadataModelIdentity(t *testing.T) {
 	}
 }
 
+func TestStreamRecorder_ResponseTransportMetadataOverridesCallerValues(t *testing.T) {
+	r := NewStreamRecorder(agento11y.GenerationStart{
+		Model: agento11y.ModelRef{Provider: "grafana", Name: "requested-model"},
+		Metadata: map[string]any{
+			transportProviderMetadataKey: "spoofed-provider",
+			transportModelMetadataKey:    "spoofed-model",
+		},
+	}, provider.CallOptions{})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartResponseMeta, Provider: "anthropic", ModelID: "response-model",
+	})
+
+	gen := r.Generation()
+	assert.Equal(t, "grafana", gen.Metadata[transportProviderMetadataKey])
+	assert.Equal(t, "requested-model", gen.Metadata[transportModelMetadataKey])
+}
+
+func TestStreamRecorder_ResponseMetadataAccumulatesWithoutErasing(t *testing.T) {
+	r := NewStreamRecorder(agento11y.GenerationStart{
+		Model: agento11y.ModelRef{Provider: "grafana", Name: "requested-model"},
+	}, provider.CallOptions{})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartResponseMeta, ResponseID: "response-1", Provider: "anthropic", ModelID: "response-model",
+	})
+	r.Observe(provider.StreamPart{Type: provider.PartResponseMeta, Provider: "grafana"})
+
+	gen := r.Generation()
+	assert.Equal(t, "response-1", gen.ResponseID)
+	assert.Equal(t, "response-model", gen.ResponseModel)
+	assert.Equal(t, "anthropic", gen.Model.Provider)
+	assert.Equal(t, "response-model", gen.Model.Name)
+}
+
 func TestStreamRecorder_NilSafe(t *testing.T) {
 	var r *StreamRecorder
 	r.Observe(provider.StreamPart{Type: provider.PartTextDelta})
 	assert.True(t, r.FirstChunkAt().IsZero())
 	assert.Nil(t, r.CallError())
 	assert.Equal(t, agento11y.Generation{}, r.Generation())
-}
-
-func TestAnthropicSignatureFromMetadata(t *testing.T) {
-	tests := []struct {
-		name string
-		meta provider.ProviderMetadata
-		want string
-	}{
-		{"nil", nil, ""},
-		{"no anthropic key", provider.ProviderMetadata{"other": json.RawMessage(`{}`)}, ""},
-		{
-			"signature present",
-			provider.ProviderMetadata{"anthropic": json.RawMessage(`{"signature":"sig-1"}`)},
-			"sig-1",
-		},
-		{
-			"no signature in object",
-			provider.ProviderMetadata{"anthropic": json.RawMessage(`{"other":"x"}`)},
-			"",
-		},
-		{
-			"malformed JSON returns empty",
-			provider.ProviderMetadata{"anthropic": json.RawMessage(`{garbage`)},
-			"",
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, anthropicSignatureFromMetadata(tc.meta))
-		})
-	}
 }

--- a/middleware/agentobservability/recording.go
+++ b/middleware/agentobservability/recording.go
@@ -128,9 +128,8 @@ func wrapRecordingStream(ctx context.Context, opts RecordingOptions, p middlewar
 
 // runStreamTee shuttles parts from the inner-model stream to the consumer
 // while observing each event through the StreamRecorder. It finalizes the
-// recorder (SetResult and, for stream errors, SetCallError) once the upstream
-// channel closes or the request context cancels. After cancellation, upstream
-// is drained on a best-effort basis to release the producer goroutine.
+// recorder (SetResult and, for stream errors or cancellation, SetCallError)
+// once the upstream channel closes or the request context cancels.
 func runStreamTee(
 	ctx context.Context,
 	upstream <-chan provider.StreamPart,
@@ -142,13 +141,13 @@ func runStreamTee(
 	defer recorder.End()
 	defer close(tee)
 
-	consumerDisconnected := false
-
+	canceled := false
 streamLoop:
 	for {
 		select {
 		case part, ok := <-upstream:
 			if !ok {
+				canceled = ctx.Err() != nil
 				break streamLoop
 			}
 			streamRec.Observe(part)
@@ -156,22 +155,21 @@ streamLoop:
 			select {
 			case tee <- part:
 			case <-ctx.Done():
-				consumerDisconnected = true
+				canceled = true
 				break streamLoop
 			}
 		case <-ctx.Done():
-			consumerDisconnected = true
+			canceled = true
 			break streamLoop
 		}
 	}
 
-	if consumerDisconnected {
-		go drainProviderStream(upstream)
-	}
 	if first := streamRec.FirstChunkAt(); !first.IsZero() {
 		recorder.SetFirstTokenAt(first)
 	}
-	if callErr := streamRec.CallError(); callErr != nil {
+	if canceled {
+		recorder.SetCallError(ctx.Err())
+	} else if callErr := streamRec.CallError(); callErr != nil {
 		recorder.SetCallError(callErr)
 	}
 
@@ -188,11 +186,6 @@ streamLoop:
 		gen.AgentVersion = ctxInfo.AgentVersion
 	}
 	recorder.SetResult(gen, nil)
-}
-
-func drainProviderStream(upstream <-chan provider.StreamPart) {
-	for range upstream {
-	}
 }
 
 // resolveClient returns the *agento11y.Client for the request, treating a

--- a/middleware/agentobservability/recording_test.go
+++ b/middleware/agentobservability/recording_test.go
@@ -335,9 +335,62 @@ func TestRecordingMiddleware_StreamPartError_RecordsUsageAndCallError(t *testing
 	assert.Equal(t, "170", usage["total_tokens"])
 }
 
-func TestRecordingMiddleware_StreamConsumerAbandons_DrainsAndRecords(t *testing.T) {
+func TestRecordingMiddleware_StreamCancellationTakesPrecedenceOverPartError(t *testing.T) {
 	env := testkit.NewEnv(t)
-	model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
+	model := &mockLanguageModel{
+		provider_: "anthropic",
+		modelID:   "claude",
+		doStream: func(ctx context.Context, _ provider.CallOptions) (*provider.StreamResult, error) {
+			stream := make(chan provider.StreamPart)
+			go func() {
+				defer close(stream)
+				stream <- provider.StreamPart{
+					Type:         provider.PartError,
+					APICallError: provider.NewAPICallError(provider.APICallErrorOptions{Message: "provider error"}),
+				}
+				<-ctx.Done()
+			}()
+			return &provider.StreamResult{Stream: stream}, nil
+		},
+	}
+	wrapped := middleware.Wrap(middleware.WrapOptions{
+		Model: model,
+		Middleware: []middleware.Middleware{RecordingMiddleware(RecordingOptions{
+			ClientResolver: func(context.Context) *agento11y.Client { return env.Client },
+		})},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	streamResult, err := wrapped.DoStream(ctx, provider.CallOptions{})
+	require.NoError(t, err)
+	_, ok := <-streamResult.Stream
+	require.True(t, ok)
+	cancel()
+	for range streamResult.Stream {
+	}
+	assert.Eventually(t, func() bool { return env.RequestCount() == 1 }, 2*time.Second, 10*time.Millisecond)
+	require.NoError(t, env.Client.Shutdown(context.Background()))
+
+	gen := env.SingleGenerationJSON(t)
+	callErr, _ := gen["call_error"].(string)
+	assert.Contains(t, callErr, "context canceled")
+	assert.NotContains(t, callErr, "provider error")
+}
+
+func TestRecordingMiddleware_StreamConsumerAbandons_RecordsCancellation(t *testing.T) {
+	env := testkit.NewEnv(t)
+	model := &mockLanguageModel{
+		provider_: "anthropic",
+		modelID:   "claude",
+		doStream: func(ctx context.Context, _ provider.CallOptions) (*provider.StreamResult, error) {
+			stream := make(chan provider.StreamPart)
+			go func() {
+				defer close(stream)
+				stream <- provider.StreamPart{Type: provider.PartTextDelta, ID: "text-1", Delta: "partial"}
+				<-ctx.Done()
+			}()
+			return &provider.StreamResult{Stream: stream}, nil
+		},
+	}
 	wrapped := middleware.Wrap(middleware.WrapOptions{
 		Model: model,
 		Middleware: []middleware.Middleware{RecordingMiddleware(RecordingOptions{
@@ -355,19 +408,28 @@ func TestRecordingMiddleware_StreamConsumerAbandons_DrainsAndRecords(t *testing.
 	require.True(t, ok)
 	cancel()
 
-	// Drain the rest of the tee channel. The recorder finalizes promptly after
-	// consumer disconnect while the provider stream drains in the background.
 	for range streamResult.Stream {
 	}
 
 	assert.Eventually(t, func() bool {
 		return env.RequestCount() >= 1
 	}, 2*time.Second, 10*time.Millisecond, "recording finalized even after consumer abandonment")
+	require.NoError(t, env.Client.Shutdown(context.Background()))
+	gen := env.SingleGenerationJSON(t)
+	callErr, _ := gen["call_error"].(string)
+	assert.Contains(t, callErr, "context canceled")
+	output, ok := gen["output"].([]any)
+	require.True(t, ok)
+	require.Len(t, output, 1)
+	message := output[0].(map[string]any)
+	parts := message["parts"].([]any)
+	require.Len(t, parts, 1)
+	assert.Equal(t, "partial", parts[0].(map[string]any)["text"])
 }
 
 func TestRecordingMiddleware_StreamCancellationFinalizesIdleProvider(t *testing.T) {
 	env := testkit.NewEnv(t)
-	upstream := make(chan provider.StreamPart)
+	upstream := make(chan provider.StreamPart, 1)
 	defer close(upstream)
 	model := &mockLanguageModel{
 		provider_: "anthropic",
@@ -396,7 +458,12 @@ func TestRecordingMiddleware_StreamCancellationFinalizesIdleProvider(t *testing.
 	assert.Eventually(t, func() bool {
 		return env.RequestCount() == 1
 	}, 2*time.Second, 10*time.Millisecond)
+	upstream <- provider.StreamPart{Type: provider.PartTextDelta, Delta: "late"}
+	assert.Never(t, func() bool { return len(upstream) == 0 }, 100*time.Millisecond, 10*time.Millisecond)
 	require.NoError(t, env.Client.Shutdown(context.Background()))
+	gen := env.SingleGenerationJSON(t)
+	callErr, _ := gen["call_error"].(string)
+	assert.Contains(t, callErr, "context canceled")
 }
 
 func TestRecordingMiddleware_NilContextProvider_LogsOnce(t *testing.T) {

--- a/middleware/agentobservability/testdata/hooks/transform_preserves_signature/hook_response.json
+++ b/middleware/agentobservability/testdata/hooks/transform_preserves_signature/hook_response.json
@@ -16,6 +16,11 @@
         "role": "assistant",
         "parts": [
           {
+            "kind": "thinking",
+            "thinking": "thinking…",
+            "metadata": {}
+          },
+          {
             "kind": "text",
             "text": "Here is your answer",
             "metadata": {}

--- a/middleware/agentobservability/testdata/stream/text_only/expected_generation.json
+++ b/middleware/agentobservability/testdata/stream/text_only/expected_generation.json
@@ -3,6 +3,7 @@
     "provider": "anthropic",
     "name": "claude-sonnet-4-5"
   },
+  "response_model": "claude-sonnet-4-5",
   "input": [
     {
       "role": "user",

--- a/middleware/agentobservability/testdata/stream/text_reasoning_signature/expected_generation.json
+++ b/middleware/agentobservability/testdata/stream/text_reasoning_signature/expected_generation.json
@@ -3,6 +3,7 @@
     "provider": "anthropic",
     "name": "claude-sonnet-4-5"
   },
+  "response_model": "claude-sonnet-4-5",
   "input": [
     {
       "role": "user",

--- a/middleware/agentobservability/testdata/stream/text_tool_call/expected_generation.json
+++ b/middleware/agentobservability/testdata/stream/text_tool_call/expected_generation.json
@@ -3,6 +3,7 @@
     "provider": "anthropic",
     "name": "claude-sonnet-4-5"
   },
+  "response_model": "claude-sonnet-4-5",
   "input": [
     {
       "role": "user",

--- a/openspec/specs/agent-observability-middleware/spec.md
+++ b/openspec/specs/agent-observability-middleware/spec.md
@@ -62,8 +62,9 @@ Context helpers:
 - `ParentGenerationIDsFromContext(ctx context.Context) []string`.
 - `WithLinkedGenerationID(ctx context.Context, id string) context.Context`.
 
-Sentinel error:
+Sentinel errors:
 - `ErrHookDenied error`.
+- `ErrHookTransformFailed error`.
 
 #### Scenario: HookDenialError unwraps to sentinel
 
@@ -127,7 +128,7 @@ If `opts.ClientResolver` is itself `nil`, the middleware SHALL behave as if ever
 
 `RecordingMiddleware` SHALL call `opts.ContextProvider(ctx)` once per request and use the returned `ContextInfo` to populate:
 - `agento11y.GenerationStart.UserID` (falls back to `agento11y.UserIDFromContext(ctx)` when `ContextInfo.UserID` is empty).
-- `agento11y.GenerationStart.Metadata` (merged on top of metadata derived from `ProviderOptions` and `params`).
+- `agento11y.GenerationStart.Metadata` (used as caller metadata; reserved derivations from `ProviderOptions`, `params`, and usage override conflicting keys in the final generation).
 - `agento11y.GenerationStart.Tags` (merged on top of any tags carried via context).
 - `agento11y.GenerationStart.AgentName` / `AgentVersion` (override `agento11y.AgentNameFromContext` / `agento11y.AgentVersionFromContext` when set).
 
@@ -153,10 +154,11 @@ If `opts.ContextProvider` is `nil`, the middleware SHALL log a warning at most o
 - `Input.Tools` is derived from `params.Tools`. Function tools map directly; provider-defined tools (e.g. Anthropic `web_search`, `code_execution`) MAY map with their type preserved so Agent Observability can annotate them.
 - `Input.MaxTokens`, `Temperature`, `TopP`, `ToolChoice` are derived from the corresponding `provider.CallOptions` fields.
 - Anthropic thinking-budget metadata (`agento11y.gen_ai.request.thinking.budget_tokens`) is derived from `params.ProviderOptions["anthropic"]` via `json.RawMessage` decoding, not by importing `providers/anthropic`.
-- `Output` is a single assistant `agento11y.Message` whose parts mirror supported `result.Content` entries (text, tool-call, reasoning, file, and reasoning-file parts).
+- `Output` contains an assistant `agento11y.Message` for supported model content and additional tool-role messages for tool-result entries.
 - `Usage` maps from `result.Usage` (input tokens, output tokens, cache hits where applicable).
 - `StopReason` is produced by `finishReasonToAgento11yStop(result.FinishReason)` and SHALL match the string values the legacy `internal/llm/claude/` path emitted (e.g. `"end_turn"`, `"max_tokens"`, `"tool_use"`, `"stop_sequence"`).
-- `Metadata` is a merge of `ctxInfo.Metadata` and `map_provider_options.go` derivations.
+- `Metadata` starts with caller metadata, then applies reserved request and usage derivations. Derived Anthropic thinking-budget and positive server-tool request counts SHALL override conflicting caller values, matching the pinned agento11y Anthropic helper.
+- Provider tool calls and results SHALL retain recoverable Anthropic discriminators, including MCP metadata and configured provider-tool aliases for web search, web fetch, code execution, and tool search. Irrecoverable provider subtypes MAY use the generic discriminator.
 - `Tags` is a merge of `ctxInfo.Tags` and any tags from context.
 
 #### Scenario: System message folds into SystemPrompt
@@ -177,6 +179,11 @@ If `opts.ContextProvider` is `nil`, the middleware SHALL log a warning at most o
 
 - **WHEN** `params.ProviderOptions["anthropic"]` carries a JSON object containing a `thinking` field with a positive `budget_tokens` value
 - **THEN** the resulting `Generation.Metadata["agento11y.gen_ai.request.thinking.budget_tokens"]` SHALL equal that integer
+
+#### Scenario: Anthropic server-tool usage is recorded
+
+- **WHEN** `result.Usage.Raw` contains positive `server_tool_use.web_search_requests` or `web_fetch_requests`
+- **THEN** generation metadata SHALL contain the corresponding Agent Observability usage keys and their sum as `total_requests`
 
 #### Scenario: Byte-equal output to agento11y anthropic helper
 
@@ -227,13 +234,14 @@ Hook preflight evaluation SHALL exclude `file` and `reasoning-file` media so rec
 
 `StreamRecorder` SHALL accumulate `agento11y.Generation.Output` from a sequence of `provider.StreamPart` values observed via `Observe`. It SHALL:
 - Append `PartTextDelta` payloads into the active assistant text part.
-- Append `PartReasoningDelta` payloads into the active assistant reasoning part. The recorder SHALL internally retain any `ProviderMetadata["anthropic"].signature` value observed on the delta (deduplicating identical values) so consumers that hold a reference to the source `provider.Message` can round-trip the signature on subsequent turns. Because `agento11y.Part` has no field for signatures today, the value is NOT serialized into `Generation.Output`; reasoning signatures live exclusively on the corresponding `provider.Message` in `params.Prompt` (see "Hooks transform preserves reasoning signatures" for the round-trip path).
-- Append `PartToolCallDelta` payloads into the active assistant tool-call part.
+- Append non-empty `PartReasoningDelta` payloads into the active assistant reasoning part. Signature-only reasoning blocks with no visible text SHALL NOT produce an Agent Observability thinking part.
+- Append `PartToolInputDelta` payloads into the active assistant tool-call part.
 - Map supported `PartFile` and `PartReasoningFile` events to media parts.
-- Record the first observed payload-bearing part's timestamp via `FirstChunkAt()`; supported file events SHALL be payload-bearing.
+- Record the first semantic model-output timestamp via `FirstChunkAt()`. Non-empty text, reasoning, and tool-input deltas, tool calls, and supported file events SHALL be payload-bearing; finish, error, tool-result, metadata, and empty-delta events SHALL NOT establish time to first token.
+- Coalesce preliminary tool-result updates by tool-call ID and include only completed tool results in the final generation output. Distinct completed results SHALL remain distinct even when an ID is reused.
 - Capture `FinishReason` from `PartFinish` and observe `Usage` from every usage-bearing stream part using the shared streaming aggregation behavior.
 
-`Generation()` SHALL return an `agento11y.Generation` whose `Output` is a single assistant message constructed from the accumulated state. Assistant text, reasoning, tool-call, and media parts SHALL retain the order in which their first provider events were observed.
+`Generation()` SHALL return an `agento11y.Generation` whose `Output` contains an assistant message for accumulated model parts plus tool-role messages for completed tool results. Assistant text, reasoning, tool-call, and media parts SHALL retain the order in which their first provider events were observed.
 
 #### Scenario: Stream usage preserves strongest values
 
@@ -249,13 +257,11 @@ Hook preflight evaluation SHALL exclude `file` and `reasoning-file` media so rec
 - **AND** `StreamRecorder.Generation()` is called at end-of-stream
 - **THEN** the resulting reasoning part in `Generation.Output` SHALL contain the concatenated reasoning text `"I think so"`
 
-#### Scenario: Reasoning signature is preserved off-band
+#### Scenario: Signature-only reasoning is omitted
 
-- **GIVEN** a stream that emits `PartReasoningDelta` events carrying `ProviderMetadata["anthropic"].signature = "sig-abc"`
-- **WHEN** `StreamRecorder.Observe` is called for each
-- **AND** `StreamRecorder.Generation()` is called at end-of-stream
-- **THEN** the resulting reasoning part in `Generation.Output` MAY omit the signature (the current `agento11y.Part` schema has no signature field)
-- **AND** the original signature SHALL remain available on the corresponding `provider.Message` in `params.Prompt`, where `HooksMiddleware.applyTransformedInput` matches by text content to preserve it across hook transforms
+- **GIVEN** a stream emits a reasoning block containing an Anthropic signature but no reasoning text
+- **WHEN** `StreamRecorder.Generation()` is called
+- **THEN** `Generation.Output` SHALL NOT contain an empty thinking part
 
 #### Scenario: Text deltas concatenate
 
@@ -265,7 +271,7 @@ Hook preflight evaluation SHALL exclude `file` and `reasoning-file` media so rec
 
 #### Scenario: Tool-call deltas accumulate by tool-call ID
 
-- **GIVEN** a stream emits multiple `PartToolCallDelta` events for the same tool-call ID with incremental JSON argument fragments
+- **GIVEN** a stream emits multiple `PartToolInputDelta` events for the same tool-call ID with incremental JSON argument fragments
 - **WHEN** the recorder is observed
 - **THEN** the resulting tool-call part SHALL have the concatenated argument JSON
 
@@ -278,7 +284,7 @@ Hook preflight evaluation SHALL exclude `file` and `reasoning-file` media so rec
 
 ### Requirement: Recording uses response model identity when available
 
-Agent Observability recording SHALL use backend response metadata as the canonical generation model identity when a successful provider response supplies both provider and model ID. When response metadata omits either provider or model ID, recording SHALL preserve the model identity from `GenerationStart`.
+Agent Observability recording SHALL use backend response metadata as the canonical generation model identity when a successful provider response supplies both provider and model ID. When response metadata omits either provider or model ID, recording SHALL preserve the model identity from `GenerationStart`. Generate and stream `ResponseModel` SHALL default to the requested model and SHALL be overridden by a non-empty response model.
 
 #### Scenario: Generate response overrides transport model identity
 
@@ -341,20 +347,20 @@ When response metadata changes the canonical generation model identity from the 
 3. Call `client.StartGeneration` (for `WrapGenerate`) or `client.StartStreamingGeneration` (for `WrapStream`).
 4. Invoke the inner model.
 5. On success:
-   - For generate: call `recorder.SetResult(MapGenerateResult(params, result, ctxInfo))`.
+   - For generate: map the result with the original `GenerationStart` so requested-model fallback is available, then call `recorder.SetResult`.
    - For stream: tee the result stream channel, feed each part to a `StreamRecorder`, and at end-of-stream call `recorder.SetResult(streamRecorder.Generation())`.
 6. On an error returned before a stream opens: call `recorder.SetCallError(err)`. When a stream emits `PartError`, call `recorder.SetCallError(err)` and also call `recorder.SetResult` with the partial generation, including aggregated usage observed before or on the error part.
 
 `RecordingMiddleware` SHALL NOT modify `params` and SHALL NOT modify the result.
 
-For streams, the recording goroutine SHALL select on `ctx.Done()` to avoid blocking on consumer disconnect, and SHALL drain the upstream channel after consumer abandonment to avoid leaking the producer goroutine.
+For streams, the recording goroutine SHALL select on `ctx.Done()` to avoid blocking on consumer disconnect. Cancellation before observed upstream completion SHALL be recorded as the call error and SHALL take precedence over an earlier `PartError`. The middleware SHALL NOT start an unbounded detached drain when the provider ignores cancellation; provider stream producers are responsible for honoring the call context.
 
 #### Scenario: Generate path records on success
 
 - **GIVEN** a `RecordingMiddleware` with a non-nil `ClientResolver`
 - **WHEN** the inner model's `DoGenerate` returns a non-nil result and `nil` error
 - **THEN** the middleware SHALL call `StartGeneration` once
-- **AND** SHALL call `recorder.SetResult` once with `MapGenerateResult(params, result, ctxInfo)`
+- **AND** SHALL call `recorder.SetResult` once with the generation mapped from `params`, `result`, `ctxInfo`, and the original `GenerationStart`
 - **AND** SHALL NOT call `recorder.SetCallError`
 
 #### Scenario: Generate path records on error
@@ -379,11 +385,12 @@ For streams, the recording goroutine SHALL select on `ctx.Done()` to avoid block
 - **AND** the consumer SHALL receive exactly the same N parts in the same order
 - **AND** `recorder.SetResult` SHALL be called once after the upstream channel closes
 
-#### Scenario: Stream goroutine cleans up on consumer disconnect
+#### Scenario: Stream cancellation records an error and cleans up
 
-- **WHEN** the consumer abandons the result stream by cancelling its context before the upstream completes
+- **WHEN** the consumer cancels its context before the upstream completes
 - **THEN** the recording goroutine SHALL NOT block indefinitely
-- **AND** the upstream channel SHALL be drained so the producer can return
+- **AND** the generation SHALL record the context cancellation as its call error
+- **AND** the middleware SHALL NOT start a detached goroutine that waits indefinitely for the upstream channel to close
 
 ### Requirement: HooksMiddleware enforces preflight policy
 
@@ -395,7 +402,7 @@ For streams, the recording goroutine SHALL select on `ctx.Done()` to avoid block
 5. Branch on the response:
    - **Deny**: return `&HookDenialError{Reason, RuleID, Cause: nil}` to the caller. The inner model SHALL NOT be invoked.
    - **Allow**: invoke the inner model with `params` unchanged.
-   - **TransformedInput**: rebuild `params.Prompt` from the transformed messages (preserving reasoning-block signatures — see "Hooks transform preserves reasoning signatures" below), then invoke the inner model with the new params.
+   - **TransformedInput**: treat the transformed input as an authoritative replacement, rebuild `params.Prompt` and the retained subset of `params.Tools`, and invoke the inner model with the new params. If any returned content cannot be reconstructed without loss or reintroducing omitted content, return `ErrHookTransformFailed` without invoking the model.
 
 #### Scenario: Allow path passes through
 
@@ -421,50 +428,57 @@ For streams, the recording goroutine SHALL select on `ctx.Done()` to avoid block
 - **THEN** the hook call SHALL be cancelled via context deadline
 - **AND** the original request context SHALL NOT be cancelled (only the derived hook-bounded context)
 
-### Requirement: Hooks transform preserves reasoning signatures and system context
+### Requirement: Hook transforms are authoritative and lossless
 
-When `EvaluateHook` returns a `TransformedInput`, `HooksMiddleware` SHALL rebuild `params.Prompt` from the transformed messages using the following algorithm:
+When `EvaluateHook` returns a non-nil `TransformedInput`, `HooksMiddleware` SHALL treat it as an authoritative replacement rather than a partial patch:
 
-1. **System messages**: if `transformed.SystemPrompt` is non-empty, the resulting prompt SHALL begin with a single `provider.Message{Role: RoleSystem}` carrying that text and SHALL NOT carry any original system messages forward. If `transformed.SystemPrompt` is empty (the zero value), the resulting prompt SHALL preserve every original system-role message from `params.Prompt` in their original order. The empty case is treated as "the hook did not touch the system context" because `messagesToAgento11y` produces an empty `SystemPrompt` both when the original prompt has no system messages AND when the hook didn't return one — the two cases are indistinguishable on the underlying SDK wire.
-2. **Reasoning preservation**: build a content-matching index over assistant-role messages in the **original** `params.Prompt` that contain reasoning parts.
-3. For each transformed non-system message:
-   - If role is assistant AND the same concatenated text appears in the index AND has not yet been consumed, use the original message verbatim (preserves `ProviderOptions["anthropic"].signature`).
-   - Otherwise, rebuild the message from the transformed `agento11y` parts.
-4. Non-assistant messages (user, tool) are rebuilt from the transformed parts directly.
+1. A non-empty `SystemPrompt` SHALL become one system message. An empty `SystemPrompt` SHALL carry no original system message forward.
+2. Every transformed message SHALL be rebuilt in returned order. Unknown roles, unsupported part kinds, empty payload parts, and malformed tool payloads SHALL fail with `ErrHookTransformFailed`.
+3. Omitted assistant parts SHALL remain omitted. The middleware SHALL NOT restore an entire original assistant message based only on visible text.
+4. An unchanged reasoning part MAY reuse the exact original part to preserve its provider signature. Matching SHALL use an unambiguous unused reasoning part with identical reasoning text; changed or ambiguous signed reasoning SHALL fail closed.
+5. Unchanged provider-executed tool calls and provider-specific tool results SHALL retain their provider fields only after an exact ID, name, and payload match. A provider-specific part that cannot be matched exactly SHALL fail closed.
+6. Because hook evaluation intentionally excludes media, message-level provider options, text-part provider options, empty reasoning metadata, and other unsupported content, a transform of a prompt containing undisclosed content SHALL fail closed rather than silently dropping or restoring it.
+7. Returned tools SHALL be matched exactly to disclosed original tool definitions. Exact retained tools MAY be preserved or reordered and omitted tools SHALL be removed; new or modified tools that cannot be reconstructed losslessly SHALL fail closed. Removing tools SHALL also fail closed when it leaves a required or specifically named `ToolChoice` unsatisfied.
+8. An empty transform SHALL fail closed. A system-only replacement is valid.
 
-The resulting prompt is the concatenation of (system messages from step 1) + (rebuilt non-system messages from steps 2-4) in that order.
+#### Scenario: Empty transform fails closed
 
-This preserves `ProviderOptions["anthropic"].signature` values on reasoning parts, which do not round-trip through Agent Observability's wire schema, **and** preserves the original system context across hook transforms that only touch user / assistant messages.
-
-#### Scenario: Reasoning signature survives transform
-
-- **GIVEN** an assistant message in `params.Prompt` carrying a reasoning part with `ProviderOptions["anthropic"].signature = "sig-xyz"`
-- **AND** `EvaluateHook` returns a `TransformedInput` that modifies only user messages, leaving the assistant message text unchanged
+- **GIVEN** a non-empty original prompt
+- **AND** `EvaluateHook` returns a non-nil but empty `TransformedInput`
 - **WHEN** the transform is applied
-- **THEN** the resulting `params.Prompt` SHALL contain an assistant message whose reasoning part has `ProviderOptions["anthropic"].signature == "sig-xyz"` byte-equal to the original
+- **THEN** `ErrHookTransformFailed` SHALL be returned
+- **AND** the inner model SHALL NOT be invoked with the original prompt
 
-#### Scenario: Modified assistant text triggers rebuild from agento11y parts
+#### Scenario: Removed assistant parts stay removed
 
-- **GIVEN** an assistant message in `params.Prompt` whose text is "abc"
-- **AND** `EvaluateHook` returns a `TransformedInput` whose corresponding assistant message has text "def"
+- **GIVEN** an original assistant message containing signed reasoning, a tool call, and visible text
+- **AND** the transformed assistant message retains the same reasoning and text but omits the tool call
 - **WHEN** the transform is applied
-- **THEN** the resulting `params.Prompt` SHALL contain an assistant message whose text equals "def"
-- **AND** the original signature (if any) SHALL NOT be carried forward (because the content did not match)
+- **THEN** only the unchanged reasoning part and transformed text SHALL be present
+- **AND** the omitted tool call SHALL NOT be restored
+- **AND** the unchanged reasoning part SHALL retain its original signature
 
-#### Scenario: System messages survive a user-only transform
+#### Scenario: Multimodal transform fails closed
 
-- **GIVEN** `params.Prompt` contains a `provider.Message{Role: RoleSystem}` with text "you are helpful" followed by a user message
-- **AND** `EvaluateHook` returns a `TransformedInput` with `SystemPrompt: ""` and a transformed user message
+- **GIVEN** an original prompt containing text and undisclosed media
+- **AND** the hook returns a transformed text message
 - **WHEN** the transform is applied
-- **THEN** the resulting `params.Prompt` SHALL begin with the original system message verbatim
-- **AND** the inner model SHALL receive a non-empty system context
+- **THEN** `ErrHookTransformFailed` SHALL be returned
+- **AND** the model SHALL NOT receive a prompt with the media silently removed
 
-#### Scenario: Hook overrides system prompt
+#### Scenario: Tool removal is applied
+
+- **GIVEN** the original request exposes a tool
+- **AND** `TransformedInput.Tools` omits that tool
+- **WHEN** the transform is applied
+- **THEN** the model SHALL receive transformed call options without that tool
+
+#### Scenario: Hook replaces system prompt
 
 - **GIVEN** `params.Prompt` contains system messages "be helpful" and "be concise"
 - **AND** `EvaluateHook` returns a `TransformedInput` with `SystemPrompt: "internal-only assistant"`
 - **WHEN** the transform is applied
-- **THEN** the resulting `params.Prompt` SHALL begin with a single system message whose text equals "internal-only assistant"
+- **THEN** the resulting prompt SHALL begin with a single system message whose text equals "internal-only assistant"
 - **AND** the original system messages SHALL NOT appear in the prompt
 
 ### Requirement: Generation-ID DAG context helpers


### PR DESCRIPTION
## Summary

- Prevent Agent Observability from emitting empty reasoning parts that fail agento11y validation and drop otherwise successful generations.
- Make hook-provided prompt/tool transforms authoritative: apply them losslessly or fail closed with `ErrHookTransformFailed`.
- Harden stream recording against cancellation, preliminary results, ambiguous tool correlation, metadata loss, and provider-discriminator drift.

Closes #62.

## Code Changes

- Reasoning mapping: omit empty reasoning consistently across request, unary response, and stream telemetry, including Anthropic signature-only reasoning events.
- Hook transforms: rebuild transformed prompts and tool sets exactly; reject undisclosed media/options, malformed roles and payloads, duplicate-key JSON, ambiguous signed reasoning, unsupported metadata, invalid tool choices, and inexact provider-tool correlation.
- Provider fidelity: preserve supported MCP, web-search/fetch, tool-search, code-execution, bash, and text-editor discriminators using exact Anthropic tool IDs and aliases.
- Stream lifecycle: record cancellation as the call error without detached drains, preserve observed partial output, exclude preliminary tool results, require semantic output for TTFT, and retain cumulative response/model metadata.
- Metadata: preserve numeric JSON precision and give derived usage and transport identity fields authoritative precedence over conflicting caller metadata.

## Tests And Fixtures

- Added focused regressions for empty reasoning, hook replacement/removal behavior, malformed and ambiguous transforms, large JSON integers, duplicate object keys, exact provider aliases, repeated stream tool IDs, cancellation precedence, partial output, TTFT classification, and response metadata accumulation.
- Updated Agent Observability conformance snapshots to reflect corrected response-model and metadata behavior.
- Updated the Agent Observability OpenSpec contract for transform failure, cancellation, metadata precedence, and tool fidelity.

## Validation

- `cd middleware/agentobservability && go test ./...`
- `cd middleware/agentobservability && go test -race ./...`
- `cd middleware/agentobservability && go vet ./...`
- `mise run lint`
- `mise run test-short`
- `mise run parity-check`
- `openspec validate --all --strict`
- Lifecycle cancellation tests repeated 50 times
- `git diff --check`

## Residual Risk

- Agent Observability is Grafana-specific and has no direct Vercel implementation to compare against; parity evidence comes from the pinned provider behavior and repository conformance fixtures.
- Provider-neutral data cannot recover provider-specific subtypes that were already discarded; those remain generic.
- The exact Anthropic provider-tool allowlist must be updated alongside future supported provider-tool IDs.
