### PR TITLE
fix(agentobservability): omit empty reasoning telemetry

### DIFF
--- a/middleware/agentobservability/map_request.go
+++ b/middleware/agentobservability/map_request.go
@@ -112,6 +112,9 @@ func contentPartToAgento11y(part provider.ContentPart, includeMedia bool) (agent
 		return agento11y.TextPart(part.Text), agento11y.PartKindText, true
 
 	case provider.ContentPartTypeReasoning:
+		if part.Text == "" {
+			return agento11y.Part{}, "", false
+		}
 		out := agento11y.ThinkingPart(part.Text)
 		out.Metadata.ProviderType = "thinking"
 		return out, agento11y.PartKindThinking, true

--- a/middleware/agentobservability/map_request_test.go
+++ b/middleware/agentobservability/map_request_test.go
@@ -45,6 +45,18 @@ func TestMessagesToAgento11y_AssistantWithReasoning(t *testing.T) {
 	assert.Equal(t, agento11y.PartKindText, msgs[0].Parts[1].Kind)
 }
 
+func TestMessagesToAgento11y_SkipsEmptyReasoning(t *testing.T) {
+	prompt := []provider.Message{provider.NewAssistantMessage(
+		provider.ReasoningPart(""),
+		provider.TextPart("answer"),
+	)}
+
+	_, msgs := messagesToAgento11y(prompt)
+	require.Len(t, msgs, 1)
+	require.Len(t, msgs[0].Parts, 1)
+	assert.Equal(t, agento11y.PartKindText, msgs[0].Parts[0].Kind)
+}
+
 func TestMessagesToAgento11y_ToolResultSplitting(t *testing.T) {
 	// A user message that mixes a text part and a tool_result part should be
 	// split: the text part lands in a RoleUser agento11y.Message; the tool_result

--- a/middleware/agentobservability/map_response.go
+++ b/middleware/agentobservability/map_response.go
@@ -74,6 +74,9 @@ func generateContentPartToAgento11y(part provider.GenerateContentPart) (agento11
 		return agento11y.TextPart(part.Text), agento11y.PartKindText, true
 
 	case provider.ContentReasoning:
+		if part.Text == "" {
+			return agento11y.Part{}, "", false
+		}
 		out := agento11y.ThinkingPart(part.Text)
 		out.Metadata.ProviderType = "thinking"
 		return out, agento11y.PartKindThinking, true

--- a/middleware/agentobservability/map_response_test.go
+++ b/middleware/agentobservability/map_response_test.go
@@ -44,6 +44,17 @@ func TestContentToAgento11yOutput_Reasoning(t *testing.T) {
 	assert.Equal(t, "thinking", msgs[0].Parts[0].Metadata.ProviderType)
 }
 
+func TestContentToAgento11yOutput_SkipsEmptyReasoning(t *testing.T) {
+	msgs := contentToAgento11yOutput([]provider.GenerateContentPart{
+		{Type: provider.ContentReasoning},
+		{Type: provider.ContentText, Text: "answer"},
+	})
+
+	require.Len(t, msgs, 1)
+	require.Len(t, msgs[0].Parts, 1)
+	assert.Equal(t, agento11y.PartKindText, msgs[0].Parts[0].Kind)
+}
+
 func TestContentToAgento11yOutput_ToolResultSplit(t *testing.T) {
 	content := []provider.GenerateContentPart{
 		{Type: provider.ContentText, Text: "Looking that up…"},

--- a/middleware/agentobservability/map_stream.go
+++ b/middleware/agentobservability/map_stream.go
@@ -329,7 +329,7 @@ func (r *StreamRecorder) buildOutput() []agento11y.Message {
 		switch ref.partType {
 		case provider.PartReasoningStart:
 			acc := r.reasonings[ref.id]
-			if acc.text.Len() == 0 && acc.signature == "" {
+			if acc.text.Len() == 0 {
 				continue
 			}
 			part := agento11y.ThinkingPart(acc.text.String())

--- a/middleware/agentobservability/map_stream_test.go
+++ b/middleware/agentobservability/map_stream_test.go
@@ -157,6 +157,25 @@ func TestStreamRecorder_TextReasoningSignature(t *testing.T) {
 	assert.Equal(t, "answer", text.Text)
 }
 
+func TestStreamRecorder_SkipsSignatureOnlyReasoning(t *testing.T) {
+	r := newRecorderForStreamTest()
+	r.Observe(provider.StreamPart{Type: provider.PartReasoningStart, ID: "r0"})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartReasoningDelta,
+		ID:   "r0",
+		ProviderMetadata: provider.ProviderMetadata{
+			"anthropic": json.RawMessage(`{"signature":"sig-abc"}`),
+		},
+	})
+	r.Observe(provider.StreamPart{Type: provider.PartReasoningEnd, ID: "r0"})
+	r.Observe(provider.StreamPart{Type: provider.PartTextDelta, ID: "t0", Delta: "answer"})
+
+	gen := r.Generation()
+	require.Len(t, gen.Output, 1)
+	require.Len(t, gen.Output[0].Parts, 1)
+	assert.Equal(t, agento11y.PartKindText, gen.Output[0].Parts[0].Kind)
+}
+
 func TestStreamRecorder_ToolCallDeltas(t *testing.T) {
 	r := newRecorderForStreamTest()
 	r.Observe(provider.StreamPart{

--- a/openspec/specs/agent-observability-middleware/spec.md
+++ b/openspec/specs/agent-observability-middleware/spec.md
@@ -149,11 +149,11 @@ If `opts.ContextProvider` is `nil`, the middleware SHALL log a warning at most o
 ### Requirement: MapGenerateResult produces agento11y.Generation
 
 `MapGenerateResult(params, result, ctxInfo)` SHALL produce an `agento11y.Generation` whose:
-- `Input.Messages` is derived from `params.Prompt`, with `provider.Message{Role: RoleSystem}` entries folded into `Generation.SystemPrompt` (single concatenated string) rather than appearing as an agento11y.Message.
+- `Input.Messages` is derived from `params.Prompt`, with `provider.Message{Role: RoleSystem}` entries folded into `Generation.SystemPrompt` (single concatenated string) rather than appearing as an agento11y.Message. Empty reasoning parts SHALL be omitted.
 - `Input.Tools` is derived from `params.Tools`. Function tools map directly; provider-defined tools (e.g. Anthropic `web_search`, `code_execution`) MAY map with their type preserved so Agent Observability can annotate them.
 - `Input.MaxTokens`, `Temperature`, `TopP`, `ToolChoice` are derived from the corresponding `provider.CallOptions` fields.
 - Anthropic thinking-budget metadata (`agento11y.gen_ai.request.thinking.budget_tokens`) is derived from `params.ProviderOptions["anthropic"]` via `json.RawMessage` decoding, not by importing `providers/anthropic`.
-- `Output` is a single assistant `agento11y.Message` whose parts mirror supported `result.Content` entries (text, tool-call, reasoning, file, and reasoning-file parts).
+- `Output` is a single assistant `agento11y.Message` whose parts mirror supported `result.Content` entries (text, tool-call, reasoning, file, and reasoning-file parts). Empty reasoning parts SHALL be omitted.
 - `Usage` maps from `result.Usage` (input tokens, output tokens, cache hits where applicable).
 - `StopReason` is produced by `finishReasonToAgento11yStop(result.FinishReason)` and SHALL match the string values the legacy `internal/llm/claude/` path emitted (e.g. `"end_turn"`, `"max_tokens"`, `"tool_use"`, `"stop_sequence"`).
 - `Metadata` is a merge of `ctxInfo.Metadata` and `map_provider_options.go` derivations.
@@ -227,7 +227,7 @@ Hook preflight evaluation SHALL exclude `file` and `reasoning-file` media so rec
 
 `StreamRecorder` SHALL accumulate `agento11y.Generation.Output` from a sequence of `provider.StreamPart` values observed via `Observe`. It SHALL:
 - Append `PartTextDelta` payloads into the active assistant text part.
-- Append `PartReasoningDelta` payloads into the active assistant reasoning part. The recorder SHALL internally retain any `ProviderMetadata["anthropic"].signature` value observed on the delta (deduplicating identical values) so consumers that hold a reference to the source `provider.Message` can round-trip the signature on subsequent turns. Because `agento11y.Part` has no field for signatures today, the value is NOT serialized into `Generation.Output`; reasoning signatures live exclusively on the corresponding `provider.Message` in `params.Prompt` (see "Hooks transform preserves reasoning signatures" for the round-trip path).
+- Append non-empty `PartReasoningDelta` payloads into the active assistant reasoning part. Signature-only reasoning blocks with no visible text SHALL NOT produce an Agent Observability thinking part.
 - Append `PartToolCallDelta` payloads into the active assistant tool-call part.
 - Map supported `PartFile` and `PartReasoningFile` events to media parts.
 - Record the first observed payload-bearing part's timestamp via `FirstChunkAt()`; supported file events SHALL be payload-bearing.
@@ -249,13 +249,11 @@ Hook preflight evaluation SHALL exclude `file` and `reasoning-file` media so rec
 - **AND** `StreamRecorder.Generation()` is called at end-of-stream
 - **THEN** the resulting reasoning part in `Generation.Output` SHALL contain the concatenated reasoning text `"I think so"`
 
-#### Scenario: Reasoning signature is preserved off-band
+#### Scenario: Signature-only reasoning is omitted
 
-- **GIVEN** a stream that emits `PartReasoningDelta` events carrying `ProviderMetadata["anthropic"].signature = "sig-abc"`
-- **WHEN** `StreamRecorder.Observe` is called for each
-- **AND** `StreamRecorder.Generation()` is called at end-of-stream
-- **THEN** the resulting reasoning part in `Generation.Output` MAY omit the signature (the current `agento11y.Part` schema has no signature field)
-- **AND** the original signature SHALL remain available on the corresponding `provider.Message` in `params.Prompt`, where `HooksMiddleware.applyTransformedInput` matches by text content to preserve it across hook transforms
+- **GIVEN** a stream emits a reasoning block containing an Anthropic signature but no reasoning text
+- **WHEN** `StreamRecorder.Generation()` is called
+- **THEN** `Generation.Output` SHALL NOT contain an empty thinking part
 
 #### Scenario: Text deltas concatenate
 


### PR DESCRIPTION
## Summary

- Omit empty reasoning parts from Agent Observability request, unary-response, and stream mappings.
- Prevent Anthropic signature-only reasoning events from producing invalid empty thinking payloads that cause successful generations to be dropped.

Closes #62.

## Tests And Fixtures

- Added regressions for empty prompt reasoning, empty generated reasoning, and signature-only streamed reasoning followed by normal text.
- Updated the Agent Observability OpenSpec contract across all three mapping paths.

## Validation

- `cd middleware/agentobservability && go test ./...`
- `cd middleware/agentobservability && go test -race ./...`
- `openspec validate --all --strict`

## Stack

- 1 of 3; targets `main`.
- Followed by #134 and #135.
