### PR TITLE
fix(agentobservability): apply hook transforms losslessly

### DIFF
--- a/middleware/agentobservability/conformance_fixtures_test.go
+++ b/middleware/agentobservability/conformance_fixtures_test.go
@@ -309,7 +309,10 @@ func hookInputs() map[string]hookFixtureInput {
 			TransformedInput: &agento11y.HookInput{
 				Messages: []agento11y.Message{
 					{Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("modified question")}},
-					{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.TextPart("Here is your answer")}},
+					{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{
+						agento11y.ThinkingPart("thinking…"),
+						agento11y.TextPart("Here is your answer"),
+					}},
 				},
 			},
 		},

--- a/middleware/agentobservability/conformance_test.go
+++ b/middleware/agentobservability/conformance_test.go
@@ -177,7 +177,9 @@ func TestConformance_Hooks(t *testing.T) {
 					// Allow without transform: prompt is unchanged.
 					got = originalPrompt
 				} else {
-					got = applyTransformedInput(originalPrompt, *hookResp.TransformedInput)
+					var err error
+					got, err = applyTransformedInput(originalPrompt, *hookResp.TransformedInput)
+					require.NoError(t, err)
 				}
 				if regenerateConformanceFixtures {
 					writeJSONFile(t, filepath.Join(dir, "expected_prompt.json"), got)

--- a/middleware/agentobservability/errors.go
+++ b/middleware/agentobservability/errors.go
@@ -6,9 +6,14 @@ import (
 	"strings"
 )
 
-// ErrHookDenied is the sentinel error wrapped by every *HookDenialError. Use
-// errors.Is(err, agentobservability.ErrHookDenied) for generic deny detection.
-var ErrHookDenied = errors.New("agent observability: hook denied request")
+var (
+	// ErrHookDenied is the sentinel error wrapped by every *HookDenialError. Use
+	// errors.Is(err, agentobservability.ErrHookDenied) for generic deny detection.
+	ErrHookDenied = errors.New("agent observability: hook denied request")
+	// ErrHookTransformFailed indicates that a hook-provided replacement could
+	// not be applied without losing or restoring request content.
+	ErrHookTransformFailed = errors.New("agent observability: hook transform failed")
+)
 
 // HookDenialError is returned by HooksMiddleware when the Agent Observability
 // preflight hook responds with action "deny". Consumers can use errors.As to

--- a/middleware/agentobservability/hooks.go
+++ b/middleware/agentobservability/hooks.go
@@ -1,8 +1,11 @@
 package agentobservability
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
+	"reflect"
 	"strings"
 
 	"github.com/grafana/agento11y/go/agento11y"
@@ -30,10 +33,9 @@ import (
 //     model.
 //  6. On allow (no TransformedInput): the inner model is invoked unchanged.
 //  7. On allow + TransformedInput: params.Prompt is rebuilt via
-//     applyTransformedInput, preserving original reasoning-block signatures
-//     where the assistant text matches; the inner model is then invoked
-//     with the new params (bypassing the middleware-level DoGenerate/DoStream
-//     closures, which captured the pre-transform params).
+//     applyTransformedInput. A transform that cannot be applied without
+//     losing request content fails closed; the inner model is otherwise
+//     invoked with the new params.
 func HooksMiddleware(opts HooksOptions) middleware.Middleware {
 	return middleware.Middleware{
 		WrapGenerate: func(ctx context.Context, p middleware.WrapGenerateParams) (*provider.GenerateResult, error) {
@@ -121,14 +123,25 @@ func evaluateHook(ctx context.Context, opts HooksOptions, model provider.Languag
 		return nil, denialErr
 	}
 
-	if resp.TransformedInput != nil && (len(resp.TransformedInput.Messages) > 0 || resp.TransformedInput.SystemPrompt != "") {
-		newPrompt := applyTransformedInput(params.Prompt, *resp.TransformedInput)
-		if len(newPrompt) > 0 {
-			span.SetAttributes(attribute.String(SpanAttrHooksResult, "transform"))
-			newParams := params
-			newParams.Prompt = newPrompt
-			return &newParams, nil
+	if resp.TransformedInput != nil {
+		newPrompt, err := applyTransformedInputWithTools(params.Prompt, params.Tools, *resp.TransformedInput)
+		if err == nil {
+			var tools []provider.Tool
+			tools, err = applyTransformedTools(params.Tools, resp.TransformedInput.Tools)
+			if err == nil {
+				err = validateTransformedToolChoice(params.ToolChoice, tools)
+			}
+			if err == nil {
+				span.SetAttributes(attribute.String(SpanAttrHooksResult, "transform"))
+				newParams := params
+				newParams.Prompt = newPrompt
+				newParams.Tools = tools
+				return &newParams, nil
+			}
 		}
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
 	}
 
 	span.SetAttributes(attribute.String(SpanAttrHooksResult, "allow"))
@@ -139,7 +152,7 @@ func evaluateHook(ctx context.Context, opts HooksOptions, model provider.Languag
 // Media is excluded because hooks predate Agent Observability media recording,
 // and sending inline data or signed URLs would widen the preflight disclosure boundary.
 func buildHookEvaluateRequest(model provider.LanguageModel, params provider.CallOptions, ctxInfo ContextInfo) agento11y.HookEvaluateRequest {
-	system, msgs := messagesToAgento11yWithMedia(params.Prompt, false)
+	system, msgs := messagesToAgento11yWithMediaAndTools(params.Prompt, false, params.Tools)
 	tools := toolsToAgento11y(params.Tools)
 
 	hookCtx := agento11y.HookContext{
@@ -185,164 +198,224 @@ func flattenMessagesForPreview(messages []agento11y.Message) string {
 	return strings.Join(parts, "\n")
 }
 
-// applyTransformedInput rebuilds an ai-sdk prompt from an agento11y.HookInput
-// while preserving the cryptographic signatures attached to reasoning blocks
-// in the original prompt's assistant messages and the system prompt that
-// the hook did not explicitly modify.
-//
-// Algorithm (matching the legacy claude path's findMatchingOriginalWithThinking):
-//
-//  1. System messages: if transformed.SystemPrompt is non-empty, replace the
-//     original system context with a single SystemMessage built from it;
-//     otherwise carry the original system messages forward unchanged. This
-//     mirrors how messagesToAgento11y folds system messages into a separate
-//     HookInput.SystemPrompt field — a hook that doesn't touch the system
-//     context returns it as "" (the zero value), and we MUST NOT silently
-//     drop the originals in that case.
-//  2. Non-system messages: index the original assistant-role messages that
-//     carry a reasoning part by their concatenated text content (excluding
-//     reasoning text). For each transformed message:
-//     - If role is assistant AND the same concatenated text appears in the
-//     index AND has not yet been consumed, keep the original message
-//     verbatim (preserves the signature).
-//     - Otherwise, rebuild the message from the transformed SDK parts.
-//
-// Reasoning signatures don't round-trip through the underlying SDK wire schema, so any
-// assistant message whose text the hook changed loses its signature.
-func applyTransformedInput(originalPrompt []provider.Message, transformed agento11y.HookInput) []provider.Message {
-	originalsWithReasoning := indexAssistantReasoningMessages(originalPrompt)
-	used := make(map[int]bool, len(originalsWithReasoning))
+// applyTransformedInput rebuilds a complete replacement prompt from a hook
+// response. It preserves reasoning signatures only on unchanged reasoning
+// parts and rejects transformations that cannot be represented faithfully.
+func applyTransformedInput(originalPrompt []provider.Message, transformed agento11y.HookInput) ([]provider.Message, error) {
+	return applyTransformedInputWithTools(originalPrompt, nil, transformed)
+}
 
-	systemMsgs := systemMessagesForTransform(originalPrompt, transformed)
+func applyTransformedInputWithTools(originalPrompt []provider.Message, tools []provider.Tool, transformed agento11y.HookInput) ([]provider.Message, error) {
+	if err := validateTransformablePrompt(originalPrompt); err != nil {
+		return nil, err
+	}
+	if len(transformed.Messages) == 0 && transformed.SystemPrompt == "" {
+		return nil, fmt.Errorf("%w: transformed input is empty", ErrHookTransformFailed)
+	}
 
-	body := make([]provider.Message, 0, len(transformed.Messages))
-	for _, agento11yMsg := range transformed.Messages {
-		role, ok := agento11yRoleToProvider(agento11yMsg.Role)
+	out := make([]provider.Message, 0, len(transformed.Messages)+1)
+	if transformed.SystemPrompt != "" {
+		out = append(out, provider.NewSystemMessage(transformed.SystemPrompt))
+	}
+
+	matcher := newTransformedPartMatcher(originalPrompt, tools)
+	for i, msg := range transformed.Messages {
+		role, ok := agento11yRoleToProvider(msg.Role)
 		if !ok {
-			continue
+			return nil, fmt.Errorf("%w: message %d has unsupported role %q", ErrHookTransformFailed, i, msg.Role)
+		}
+		if err := validateTransformedMessage(msg); err != nil {
+			return nil, fmt.Errorf("%w: message %d: %v", ErrHookTransformFailed, i, err)
 		}
 
-		if role == provider.RoleAssistant {
-			text := concatAssistantTextFromAgento11y(agento11yMsg)
-			if text != "" {
-				if idx, orig, found := findMatching(originalsWithReasoning, text, used); found {
-					used[idx] = true
-					body = append(body, orig)
-					continue
+		parts, err := rebuildPartsFromAgento11y(msg.Parts, matcher)
+		if err != nil {
+			return nil, fmt.Errorf("%w: message %d: %v", ErrHookTransformFailed, i, err)
+		}
+		if len(parts) == 0 {
+			return nil, fmt.Errorf("%w: message %d has no supported parts", ErrHookTransformFailed, i)
+		}
+		out = append(out, provider.Message{Role: role, Content: parts})
+	}
+	return out, nil
+}
+
+func validateTransformablePrompt(prompt []provider.Message) error {
+	for i, msg := range prompt {
+		if len(msg.ProviderOptions) > 0 {
+			return fmt.Errorf("%w: original message %d has undisclosed provider options", ErrHookTransformFailed, i)
+		}
+		switch msg.Role {
+		case provider.RoleSystem:
+			for _, part := range msg.Content {
+				if len(part.ProviderOptions) > 0 {
+					return fmt.Errorf("%w: original system message %d has undisclosed part provider options", ErrHookTransformFailed, i)
+				}
+				if part.Type != provider.ContentPartTypeText {
+					return fmt.Errorf("%w: original system message %d contains undisclosed %q content", ErrHookTransformFailed, i, part.Type)
+				}
+			}
+			continue
+		case provider.RoleUser, provider.RoleAssistant, provider.RoleTool:
+		default:
+			return fmt.Errorf("%w: original message %d has unsupported role %q", ErrHookTransformFailed, i, msg.Role)
+		}
+		for _, part := range msg.Content {
+			switch part.Type {
+			case provider.ContentPartTypeText:
+				if len(part.ProviderOptions) > 0 {
+					return fmt.Errorf("%w: original message %d has undisclosed text provider options", ErrHookTransformFailed, i)
+				}
+			case provider.ContentPartTypeReasoning:
+				if msg.Role != provider.RoleAssistant {
+					return fmt.Errorf("%w: original message %d has reasoning under role %q", ErrHookTransformFailed, i, msg.Role)
+				}
+				if len(part.ProviderOptions) > 0 && !hasSupportedReasoningSignature(part.ProviderOptions) {
+					return fmt.Errorf("%w: original message %d has unsupported reasoning metadata", ErrHookTransformFailed, i)
+				}
+				if part.Text == "" && len(part.ProviderOptions) > 0 {
+					return fmt.Errorf("%w: original message %d has undisclosed empty reasoning metadata", ErrHookTransformFailed, i)
+				}
+			case provider.ContentPartTypeToolCall, provider.ContentPartTypeToolResult:
+			default:
+				return fmt.Errorf("%w: original message %d contains undisclosed %q content", ErrHookTransformFailed, i, part.Type)
+			}
+		}
+	}
+	return nil
+}
+
+func hasSupportedReasoningSignature(options provider.ProviderOptions) bool {
+	if len(options) != 1 {
+		return false
+	}
+	option, ok := options["anthropic"].(provider.RawProviderOption)
+	if !ok || option.Key != "anthropic" {
+		return false
+	}
+	value, ok := decodeJSONValue(option.Raw)
+	if !ok {
+		return false
+	}
+	object, ok := value.(map[string]any)
+	if !ok || len(object) != 1 {
+		return false
+	}
+	signature, ok := object["signature"].(string)
+	return ok && signature != ""
+}
+
+func applyTransformedTools(original []provider.Tool, transformed []agento11y.ToolDefinition) ([]provider.Tool, error) {
+	if len(transformed) == 0 {
+		return nil, nil
+	}
+	used := make([]bool, len(original))
+	out := make([]provider.Tool, 0, len(transformed))
+	for i, transformedTool := range transformed {
+		if len(transformedTool.InputSchema) > 0 {
+			if _, ok := decodeJSONValue(transformedTool.InputSchema); !ok {
+				return nil, fmt.Errorf("%w: transformed tool %d has invalid input schema", ErrHookTransformFailed, i)
+			}
+		}
+		match := -1
+		for j, tool := range original {
+			mapped := toolsToAgento11y([]provider.Tool{tool})
+			if used[j] || len(mapped) != 1 || !toolDefinitionEqual(mapped[0], transformedTool) {
+				continue
+			}
+			if match >= 0 {
+				return nil, fmt.Errorf("%w: transformed tool %d is ambiguous", ErrHookTransformFailed, i)
+			}
+			match = j
+		}
+		if match < 0 {
+			return nil, fmt.Errorf("%w: transformed tool %d cannot be reconstructed", ErrHookTransformFailed, i)
+		}
+		used[match] = true
+		out = append(out, original[match])
+	}
+	return out, nil
+}
+
+func validateTransformedToolChoice(choice *provider.ToolChoice, tools []provider.Tool) error {
+	if choice == nil {
+		return nil
+	}
+	switch choice.Type {
+	case provider.ToolChoiceAuto, provider.ToolChoiceNone:
+		return nil
+	case provider.ToolChoiceRequired:
+		if len(tools) == 0 {
+			return fmt.Errorf("%w: required tool choice has no transformed tools", ErrHookTransformFailed)
+		}
+		return nil
+	case provider.ToolChoiceTool:
+		for _, tool := range tools {
+			if tool.Name == choice.ToolName {
+				return nil
+			}
+		}
+		return fmt.Errorf("%w: selected tool %q was removed by transform", ErrHookTransformFailed, choice.ToolName)
+	default:
+		return fmt.Errorf("%w: unsupported tool choice %q", ErrHookTransformFailed, choice.Type)
+	}
+}
+
+func toolDefinitionEqual(a, b agento11y.ToolDefinition) bool {
+	return a.Name == b.Name &&
+		a.Description == b.Description &&
+		a.Type == b.Type &&
+		a.Deferred == b.Deferred &&
+		jsonValueEqual(a.InputSchema, b.InputSchema)
+}
+
+func validateTransformedMessage(message agento11y.Message) error {
+	if message.Name != "" {
+		return fmt.Errorf("message name cannot be reconstructed")
+	}
+	generation := agento11y.Generation{
+		Model: agento11y.ModelRef{Provider: "hook", Name: "transform"},
+		Input: []agento11y.Message{message},
+	}
+	if err := generation.Validate(); err != nil {
+		return err
+	}
+	for i, part := range message.Parts {
+		switch part.Kind {
+		case agento11y.PartKindText:
+			if part.Metadata.ProviderType != "" {
+				return fmt.Errorf("part %d has unsupported text provider type %q", i, part.Metadata.ProviderType)
+			}
+		case agento11y.PartKindThinking:
+			if part.Metadata.ProviderType != "" && part.Metadata.ProviderType != "thinking" {
+				return fmt.Errorf("part %d has unsupported thinking provider type %q", i, part.Metadata.ProviderType)
+			}
+		case agento11y.PartKindToolCall:
+			if strings.TrimSpace(part.ToolCall.ID) == "" || strings.TrimSpace(part.ToolCall.Name) == "" {
+				return fmt.Errorf("part %d tool call requires id and name", i)
+			}
+			if len(part.ToolCall.InputJSON) > 0 {
+				if _, ok := decodeJSONValue(part.ToolCall.InputJSON); !ok {
+					return fmt.Errorf("part %d has invalid tool call JSON", i)
+				}
+			}
+		case agento11y.PartKindToolResult:
+			if strings.TrimSpace(part.ToolResult.ToolCallID) == "" || strings.TrimSpace(part.ToolResult.Name) == "" {
+				return fmt.Errorf("part %d tool result requires id and name", i)
+			}
+			hasText := part.ToolResult.Content != ""
+			hasJSON := len(part.ToolResult.ContentJSON) > 0
+			if hasText == hasJSON {
+				return fmt.Errorf("part %d tool result requires exactly one content payload", i)
+			}
+			if hasJSON {
+				if _, ok := decodeJSONValue(part.ToolResult.ContentJSON); !ok {
+					return fmt.Errorf("part %d has invalid tool result JSON", i)
 				}
 			}
 		}
-
-		parts := rebuildPartsFromAgento11y(agento11yMsg.Parts)
-		if len(parts) == 0 {
-			continue
-		}
-		body = append(body, provider.Message{Role: role, Content: parts})
 	}
-
-	if len(systemMsgs) == 0 && len(body) == 0 {
-		return nil
-	}
-
-	out := make([]provider.Message, 0, len(systemMsgs)+len(body))
-	out = append(out, systemMsgs...)
-	out = append(out, body...)
-	return out
-}
-
-// systemMessagesForTransform returns the system-role messages that should
-// precede the rebuilt non-system messages after a hook transform.
-//
-// Behavior:
-//   - transformed.SystemPrompt != "": the hook explicitly set a new system
-//     prompt → emit a single SystemMessage carrying that text. Any original
-//     system messages are replaced.
-//   - transformed.SystemPrompt == "": the hook either didn't touch the
-//     system context or explicitly cleared it. We treat the zero value as
-//     "didn't touch" — preserve the originals — because messagesToAgento11y
-//     also produces "" when the original prompt has no system messages,
-//     so the two cases are indistinguishable on the underlying SDK wire.
-//
-// This mirrors how the legacy internal Agent Observability integration
-// handled the same edge case: hooks transform what they touch and leave the
-// rest alone.
-func systemMessagesForTransform(originalPrompt []provider.Message, transformed agento11y.HookInput) []provider.Message {
-	if text := strings.TrimSpace(transformed.SystemPrompt); text != "" {
-		return []provider.Message{{
-			Role:    provider.RoleSystem,
-			Content: []provider.ContentPart{provider.TextPart(transformed.SystemPrompt)},
-		}}
-	}
-	originals := make([]provider.Message, 0)
-	for _, msg := range originalPrompt {
-		if msg.Role == provider.RoleSystem {
-			originals = append(originals, msg)
-		}
-	}
-	return originals
-}
-
-type indexedMessage struct {
-	idx     int
-	message provider.Message
-	textKey string
-}
-
-func indexAssistantReasoningMessages(prompt []provider.Message) []indexedMessage {
-	var out []indexedMessage
-	for i, msg := range prompt {
-		if msg.Role != provider.RoleAssistant {
-			continue
-		}
-		hasReasoning := false
-		for _, part := range msg.Content {
-			if part.Type == provider.ContentPartTypeReasoning {
-				hasReasoning = true
-				break
-			}
-		}
-		if !hasReasoning {
-			continue
-		}
-		out = append(out, indexedMessage{
-			idx:     i,
-			message: msg,
-			textKey: concatAssistantText(msg),
-		})
-	}
-	return out
-}
-
-func concatAssistantText(msg provider.Message) string {
-	var parts []string
-	for _, p := range msg.Content {
-		if p.Type == provider.ContentPartTypeText && p.Text != "" {
-			parts = append(parts, p.Text)
-		}
-	}
-	return strings.Join(parts, "")
-}
-
-func concatAssistantTextFromAgento11y(msg agento11y.Message) string {
-	var parts []string
-	for _, p := range msg.Parts {
-		if p.Kind == agento11y.PartKindText && p.Text != "" {
-			parts = append(parts, p.Text)
-		}
-	}
-	return strings.Join(parts, "")
-}
-
-func findMatching(originals []indexedMessage, text string, used map[int]bool) (int, provider.Message, bool) {
-	for _, m := range originals {
-		if used[m.idx] {
-			continue
-		}
-		if m.textKey == text {
-			return m.idx, m.message, true
-		}
-	}
-	return 0, provider.Message{}, false
+	return nil
 }
 
 func agento11yRoleToProvider(role agento11y.Role) (provider.Role, bool) {
@@ -358,37 +431,186 @@ func agento11yRoleToProvider(role agento11y.Role) (provider.Role, bool) {
 	}
 }
 
-// rebuildPartsFromAgento11y converts an agento11y message's parts back to ai-sdk
-// ContentParts. Reasoning parts come back WITHOUT signatures (which don't
-// round-trip through the underlying SDK wire); callers that need signature
-// preservation match against the original message via the algorithm in
-// applyTransformedInput rather than rebuilding from these parts.
-func rebuildPartsFromAgento11y(parts []agento11y.Part) []provider.ContentPart {
+type transformedPartCandidate struct {
+	part provider.ContentPart
+	used bool
+}
+
+type transformedPartMatcher struct {
+	tools       []provider.Tool
+	reasonings  []transformedPartCandidate
+	toolCalls   []transformedPartCandidate
+	toolResults []transformedPartCandidate
+}
+
+func newTransformedPartMatcher(prompt []provider.Message, tools []provider.Tool) *transformedPartMatcher {
+	matcher := &transformedPartMatcher{tools: tools}
+	for _, msg := range prompt {
+		for _, part := range msg.Content {
+			candidate := transformedPartCandidate{part: part}
+			switch part.Type {
+			case provider.ContentPartTypeReasoning:
+				matcher.reasonings = append(matcher.reasonings, candidate)
+			case provider.ContentPartTypeToolCall:
+				matcher.toolCalls = append(matcher.toolCalls, candidate)
+			case provider.ContentPartTypeToolResult:
+				matcher.toolResults = append(matcher.toolResults, candidate)
+			}
+		}
+	}
+	return matcher
+}
+
+func rebuildPartsFromAgento11y(parts []agento11y.Part, matcher *transformedPartMatcher) ([]provider.ContentPart, error) {
 	out := make([]provider.ContentPart, 0, len(parts))
-	for _, p := range parts {
+	for i, p := range parts {
+		var part provider.ContentPart
+		var err error
 		switch p.Kind {
 		case agento11y.PartKindText:
 			if p.Text == "" {
-				continue
+				return nil, fmt.Errorf("part %d has empty text", i)
 			}
-			out = append(out, provider.TextPart(p.Text))
+			part = provider.TextPart(p.Text)
 		case agento11y.PartKindThinking:
-			// Drop reasoning parts: signatures can't survive a round-trip, and
-			// callers should match against the original message instead.
-			continue
+			if p.Thinking == "" {
+				return nil, fmt.Errorf("part %d has empty thinking", i)
+			}
+			part, err = matcher.matchReasoning(p.Thinking)
 		case agento11y.PartKindToolCall:
-			if p.ToolCall == nil {
-				continue
-			}
-			out = append(out, provider.ToolCallPart(p.ToolCall.ID, p.ToolCall.Name, p.ToolCall.InputJSON))
+			part, err = matcher.matchToolCall(p.ToolCall, p.Metadata.ProviderType)
 		case agento11y.PartKindToolResult:
-			if p.ToolResult == nil {
-				continue
-			}
-			out = append(out, toolResultPartFromAgento11y(p.ToolResult))
+			part, err = matcher.matchToolResult(p.ToolResult, p.Metadata.ProviderType)
+		default:
+			return nil, fmt.Errorf("part %d has unsupported kind %q", i, p.Kind)
 		}
+		if err != nil {
+			return nil, fmt.Errorf("part %d: %w", i, err)
+		}
+		out = append(out, part)
 	}
-	return out
+	return out, nil
+}
+
+func (m *transformedPartMatcher) matchReasoning(text string) (provider.ContentPart, error) {
+	match := -1
+	for i := range m.reasonings {
+		if m.reasonings[i].used || m.reasonings[i].part.Text != text {
+			continue
+		}
+		if match >= 0 {
+			return provider.ContentPart{}, fmt.Errorf("reasoning signature is ambiguous")
+		}
+		match = i
+	}
+	if match < 0 {
+		for i := range m.reasonings {
+			if len(m.reasonings[i].part.ProviderOptions) > 0 {
+				return provider.ContentPart{}, fmt.Errorf("reasoning signature cannot be preserved")
+			}
+		}
+		return provider.ReasoningPart(text), nil
+	}
+	m.reasonings[match].used = true
+	return m.reasonings[match].part, nil
+}
+
+func (m *transformedPartMatcher) matchToolCall(call *agento11y.ToolCall, providerType string) (provider.ContentPart, error) {
+	rebuilt := provider.ToolCallPart(call.ID, call.Name, call.InputJSON)
+	match := -1
+	providerSpecific := false
+	for i := range m.toolCalls {
+		candidate := m.toolCalls[i].part
+		if candidate.ToolCallID != call.ID {
+			continue
+		}
+		mapped, _, ok := contentPartToAgento11yWithTools(candidate, true, m.tools)
+		candidateProviderType := mapped.Metadata.ProviderType
+		providerSpecific = providerSpecific || candidate.ProviderExecuted || len(candidate.ProviderOptions) > 0 ||
+			(ok && candidateProviderType != "" && candidateProviderType != "tool_use")
+		if m.toolCalls[i].used {
+			continue
+		}
+		if candidate.ToolName != call.Name || !jsonValueEqual(candidate.Input, call.InputJSON) {
+			continue
+		}
+		if !ok || candidateProviderType != providerType {
+			continue
+		}
+		if match >= 0 {
+			return provider.ContentPart{}, fmt.Errorf("tool call %q is ambiguous", call.ID)
+		}
+		match = i
+	}
+	if match >= 0 {
+		candidate := m.toolCalls[match].part
+		m.toolCalls[match].used = true
+		return candidate, nil
+	}
+	if providerSpecific || (providerType != "" && providerType != "tool_use") {
+		return provider.ContentPart{}, fmt.Errorf("provider tool call %q cannot be reconstructed", call.ID)
+	}
+	return rebuilt, nil
+}
+
+func (m *transformedPartMatcher) matchToolResult(result *agento11y.ToolResult, providerType string) (provider.ContentPart, error) {
+	rebuilt := toolResultPartFromAgento11y(result)
+	match := -1
+	providerSpecific := false
+	for i := range m.toolResults {
+		candidate := m.toolResults[i].part
+		if candidate.ToolCallID != result.ToolCallID {
+			continue
+		}
+		mapped, _, ok := contentPartToAgento11yWithTools(candidate, true, m.tools)
+		candidateProviderType := mapped.Metadata.ProviderType
+		providerSpecific = providerSpecific || candidate.ProviderExecuted || len(candidate.ProviderOptions) > 0 ||
+			(ok && candidateProviderType != "" && candidateProviderType != "tool_result")
+		if m.toolResults[i].used {
+			continue
+		}
+		if !ok || !toolResultEqual(mapped.ToolResult, result) || candidateProviderType != providerType {
+			continue
+		}
+		if match >= 0 {
+			return provider.ContentPart{}, fmt.Errorf("tool result %q is ambiguous", result.ToolCallID)
+		}
+		match = i
+	}
+	if match >= 0 {
+		candidate := m.toolResults[match].part
+		m.toolResults[match].used = true
+		return candidate, nil
+	}
+	if providerSpecific || (providerType != "" && providerType != "tool_result") {
+		return provider.ContentPart{}, fmt.Errorf("provider tool result %q cannot be reconstructed", result.ToolCallID)
+	}
+	return rebuilt, nil
+}
+
+func toolResultEqual(a, b *agento11y.ToolResult) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.ToolCallID == b.ToolCallID &&
+		a.Name == b.Name &&
+		a.IsError == b.IsError &&
+		a.Content == b.Content &&
+		jsonValueEqual(a.ContentJSON, b.ContentJSON)
+}
+
+func jsonValueEqual(a, b json.RawMessage) bool {
+	a = bytes.TrimSpace(a)
+	b = bytes.TrimSpace(b)
+	if len(a) == 0 || len(b) == 0 {
+		return len(a) == len(b)
+	}
+	if !json.Valid(a) || !json.Valid(b) {
+		return false
+	}
+	left, leftOK := decodeJSONValue(a)
+	right, rightOK := decodeJSONValue(b)
+	return leftOK && rightOK && reflect.DeepEqual(left, right)
 }
 
 func toolResultPartFromAgento11y(result *agento11y.ToolResult) provider.ContentPart {

--- a/middleware/agentobservability/hooks_test.go
+++ b/middleware/agentobservability/hooks_test.go
@@ -117,6 +117,144 @@ func TestHooksMiddleware_AllowPassesThrough(t *testing.T) {
 	assert.Equal(t, 1, model.generateHit)
 }
 
+func TestHooksMiddleware_TransformFailureDoesNotInvokeModel(t *testing.T) {
+	tests := []struct {
+		name        string
+		prompt      []provider.Message
+		transformed agento11y.HookInput
+	}{
+		{
+			name:        "empty transform",
+			prompt:      []provider.Message{provider.UserText("secret")},
+			transformed: agento11y.HookInput{},
+		},
+		{
+			name: "multimodal input",
+			prompt: []provider.Message{provider.NewUserMessage(
+				provider.TextPart("describe this"),
+				provider.FilePart("image/png", provider.DataContent{URL: "https://example.com/image.png"}),
+			)},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role:  agento11y.RoleUser,
+				Parts: []agento11y.Part{agento11y.TextPart("redacted")},
+			}}},
+		},
+		{
+			name: "message provider options",
+			prompt: []provider.Message{{
+				Role:    provider.RoleUser,
+				Content: []provider.ContentPart{provider.TextPart("input")},
+				ProviderOptions: provider.ProviderOptions{
+					"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"cacheControl":{"type":"ephemeral"}}`)},
+				},
+			}},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("filtered")},
+			}}},
+		},
+		{
+			name: "text provider options",
+			prompt: []provider.Message{provider.NewUserMessage(provider.ContentPart{
+				Type: provider.ContentPartTypeText,
+				Text: "input",
+				ProviderOptions: provider.ProviderOptions{
+					"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"cacheControl":{"type":"ephemeral"}}`)},
+				},
+			})},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("filtered")},
+			}}},
+		},
+		{
+			name: "empty reasoning metadata",
+			prompt: []provider.Message{provider.NewAssistantMessage(provider.ContentPart{
+				Type: provider.ContentPartTypeReasoning,
+				ProviderOptions: provider.ProviderOptions{
+					"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"redactedData":"secret"}`)},
+				},
+			})},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.TextPart("filtered")},
+			}}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newHooksTestServer(t, agento11y.HookEvaluateResponse{
+				Action:           agento11y.HookActionAllow,
+				TransformedInput: &tc.transformed,
+			})
+			model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
+			client := h.clientWithHooksEnabled()
+			wrapped := middleware.Wrap(middleware.WrapOptions{
+				Model: model,
+				Middleware: []middleware.Middleware{HooksMiddleware(HooksOptions{
+					ClientResolver: func(context.Context) *agento11y.Client { return client },
+				})},
+			})
+
+			_, err := wrapped.DoGenerate(context.Background(), provider.CallOptions{Prompt: tc.prompt})
+			require.ErrorIs(t, err, ErrHookTransformFailed)
+			assert.Equal(t, 0, model.generateHit)
+		})
+	}
+}
+
+func TestHooksMiddleware_TransformFailureBlocksStream(t *testing.T) {
+	transformed := agento11y.HookInput{}
+	h := newHooksTestServer(t, agento11y.HookEvaluateResponse{
+		Action:           agento11y.HookActionAllow,
+		TransformedInput: &transformed,
+	})
+	model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
+	client := h.clientWithHooksEnabled()
+	wrapped := middleware.Wrap(middleware.WrapOptions{
+		Model: model,
+		Middleware: []middleware.Middleware{HooksMiddleware(HooksOptions{
+			ClientResolver: func(context.Context) *agento11y.Client { return client },
+		})},
+	})
+
+	_, err := wrapped.DoStream(context.Background(), provider.CallOptions{Prompt: []provider.Message{provider.UserText("secret")}})
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+	assert.Equal(t, 0, model.streamHit)
+}
+
+func TestHooksMiddleware_TransformAppliesToStream(t *testing.T) {
+	originalTools := []provider.Tool{
+		{Type: provider.ToolTypeFunction, Name: "keep", Description: "kept", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		{Type: provider.ToolTypeFunction, Name: "remove", Description: "removed", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+	transformed := agento11y.HookInput{
+		Messages: []agento11y.Message{{
+			Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("filtered")},
+		}},
+		Tools: toolsToAgento11y(originalTools[:1]),
+	}
+	h := newHooksTestServer(t, agento11y.HookEvaluateResponse{
+		Action: agento11y.HookActionAllow, TransformedInput: &transformed,
+	})
+	model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
+	client := h.clientWithHooksEnabled()
+	wrapped := middleware.Wrap(middleware.WrapOptions{
+		Model: model,
+		Middleware: []middleware.Middleware{HooksMiddleware(HooksOptions{
+			ClientResolver: func(context.Context) *agento11y.Client { return client },
+		})},
+	})
+
+	result, err := wrapped.DoStream(context.Background(), provider.CallOptions{
+		Prompt: []provider.Message{provider.UserText("secret")}, Tools: originalTools,
+	})
+	require.NoError(t, err)
+	for range result.Stream {
+	}
+	require.Equal(t, 1, model.streamHit)
+	require.Equal(t, []provider.Message{provider.UserText("filtered")}, model.lastParams.Prompt)
+	require.Equal(t, originalTools[:1], model.lastParams.Tools)
+}
+
 func TestBuildHookEvaluateRequest_ExcludesMedia(t *testing.T) {
 	model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
 	request := buildHookEvaluateRequest(model, provider.CallOptions{
@@ -189,11 +327,7 @@ func TestHooksMiddleware_MaxLatencyTimeout(t *testing.T) {
 	require.NoError(t, ctx.Err())
 }
 
-func TestHooksMiddleware_TransformedInput_PreservesReasoningSignature(t *testing.T) {
-	// Original assistant message carries a reasoning part with a signature.
-	// The hook returns a transform that keeps the assistant text identical.
-	// We expect the resulting prompt to keep the original assistant message
-	// verbatim (signature preserved).
+func TestHooksMiddleware_TransformedInput_PreservesReasoningSignatureWithoutRestoringRemovedParts(t *testing.T) {
 	originalReasoning := provider.ContentPart{
 		Type: provider.ContentPartTypeReasoning,
 		Text: "thinking…",
@@ -204,46 +338,500 @@ func TestHooksMiddleware_TransformedInput_PreservesReasoningSignature(t *testing
 			},
 		},
 	}
-	originalAssistant := provider.NewAssistantMessage(
-		originalReasoning,
-		provider.TextPart("Here is your answer"),
-	)
 	originalPrompt := []provider.Message{
 		provider.UserText("question"),
-		originalAssistant,
+		provider.NewAssistantMessage(
+			originalReasoning,
+			provider.ToolCallPart("call-1", "lookup", json.RawMessage(`{"query":"secret"}`)),
+			provider.TextPart("Here is your answer"),
+		),
 	}
-
-	// Hook response: same assistant text, modified user message.
 	transformed := agento11y.HookInput{
 		Messages: []agento11y.Message{
 			{Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("modified question")}},
-			{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.TextPart("Here is your answer")}},
+			{Role: agento11y.RoleAssistant, Parts: []agento11y.Part{
+				agento11y.ThinkingPart("thinking…"),
+				agento11y.TextPart("Here is your answer"),
+			}},
 		},
 	}
 
-	newPrompt := applyTransformedInput(originalPrompt, transformed)
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
 	require.Len(t, newPrompt, 2)
-
-	assert.Equal(t, provider.RoleUser, newPrompt[0].Role)
-	require.Len(t, newPrompt[0].Content, 1)
 	assert.Equal(t, "modified question", newPrompt[0].Content[0].Text)
 
-	// Assistant message must be the original verbatim (with reasoning + signature).
 	assistant := newPrompt[1]
-	assert.Equal(t, provider.RoleAssistant, assistant.Role)
-	require.Len(t, assistant.Content, 2)
+	require.Len(t, assistant.Content, 2, "removed tool call must not be restored")
 	assert.Equal(t, provider.ContentPartTypeReasoning, assistant.Content[0].Type)
-	// Signature byte-equal preserved.
 	raw, ok := assistant.Content[0].ProviderOptions["anthropic"].(provider.RawProviderOption)
-	require.True(t, ok, "anthropic option preserved as RawProviderOption")
+	require.True(t, ok)
 	assert.JSONEq(t, `{"signature":"sig-xyz"}`, string(raw.Raw))
+	assert.Equal(t, "Here is your answer", assistant.Content[1].Text)
+}
+
+func TestHooksMiddleware_TransformedInput_DoesNotRestoreOmittedReasoning(t *testing.T) {
+	originalPrompt := []provider.Message{provider.NewAssistantMessage(
+		provider.ContentPart{
+			Type: provider.ContentPartTypeReasoning,
+			Text: "thinking",
+			ProviderOptions: provider.ProviderOptions{
+				"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"signature":"sig"}`)},
+			},
+		},
+		provider.TextPart("answer"),
+	)}
+	transformed := agento11y.HookInput{Messages: []agento11y.Message{{
+		Role:  agento11y.RoleAssistant,
+		Parts: []agento11y.Part{agento11y.TextPart("answer")},
+	}}}
+
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
+	require.Len(t, newPrompt, 1)
+	require.Len(t, newPrompt[0].Content, 1)
+	assert.Equal(t, provider.ContentPartTypeText, newPrompt[0].Content[0].Type)
+}
+
+func TestHooksMiddleware_TransformedInput_PreservesProviderToolFields(t *testing.T) {
+	originalToolCall := provider.ToolCallPart("call-1", "remote_lookup", json.RawMessage(`{"query":"x"}`))
+	originalToolCall.ProviderOptions = provider.ProviderOptions{
+		"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"type":"mcp-tool-use"}`)},
+	}
+	originalPrompt := []provider.Message{provider.NewAssistantMessage(originalToolCall)}
+	transformedCall := agento11y.ToolCallPart(agento11y.ToolCall{
+		ID: "call-1", Name: "remote_lookup", InputJSON: json.RawMessage(`{"query":"x"}`),
+	})
+	transformedCall.Metadata.ProviderType = "mcp_tool_use"
+	transformed := agento11y.HookInput{Messages: []agento11y.Message{{
+		Role:  agento11y.RoleAssistant,
+		Parts: []agento11y.Part{transformedCall},
+	}}}
+
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
+	require.Len(t, newPrompt, 1)
+	require.Len(t, newPrompt[0].Content, 1)
+	assert.False(t, newPrompt[0].Content[0].ProviderExecuted)
+	assert.Equal(t, originalToolCall.ProviderOptions, newPrompt[0].Content[0].ProviderOptions)
+}
+
+func TestHooksMiddleware_TransformedInput_MatchesSignedReasoningAfterRemovedAssistant(t *testing.T) {
+	reasoning := func(text, signature string) provider.ContentPart {
+		return provider.ContentPart{
+			Type: provider.ContentPartTypeReasoning,
+			Text: text,
+			ProviderOptions: provider.ProviderOptions{
+				"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"signature":"` + signature + `"}`)},
+			},
+		}
+	}
+	originalPrompt := []provider.Message{
+		provider.NewAssistantMessage(reasoning("first thought", "sig-1"), provider.TextPart("first")),
+		provider.NewAssistantMessage(reasoning("second thought", "sig-2"), provider.TextPart("second")),
+	}
+	transformed := agento11y.HookInput{Messages: []agento11y.Message{{
+		Role: agento11y.RoleAssistant,
+		Parts: []agento11y.Part{
+			agento11y.ThinkingPart("second thought"),
+			agento11y.TextPart("second"),
+		},
+	}}}
+
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
+	raw := newPrompt[0].Content[0].ProviderOptions["anthropic"].(provider.RawProviderOption)
+	assert.JSONEq(t, `{"signature":"sig-2"}`, string(raw.Raw))
+}
+
+func TestApplyTransformedInput_RejectsMalformedContent(t *testing.T) {
+	signedReasoning := provider.ContentPart{
+		Type: provider.ContentPartTypeReasoning,
+		Text: "original",
+		ProviderOptions: provider.ProviderOptions{
+			"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"signature":"sig"}`)},
+		},
+	}
+	tests := []struct {
+		name        string
+		original    []provider.Message
+		transformed agento11y.HookInput
+	}{
+		{
+			name:     "unknown role",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: "unknown", Parts: []agento11y.Part{agento11y.TextPart("input")},
+			}}},
+		},
+		{
+			name:     "message name",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleUser, Name: "named", Parts: []agento11y.Part{agento11y.TextPart("input")},
+			}}},
+		},
+		{
+			name:     "text provider metadata",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleUser,
+				Parts: []agento11y.Part{{
+					Kind: agento11y.PartKindText, Text: "input",
+					Metadata: agento11y.PartMetadata{ProviderType: "server_tool_use"},
+				}},
+			}}},
+		},
+		{
+			name: "original reasoning under user role",
+			original: []provider.Message{{
+				Role: provider.RoleUser,
+				Content: []provider.ContentPart{{
+					Type: provider.ContentPartTypeReasoning, Text: "thinking",
+				}},
+			}},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.ThinkingPart("thinking")},
+			}}},
+		},
+		{
+			name:     "missing tool payload",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant, Parts: []agento11y.Part{{Kind: agento11y.PartKindToolCall}},
+			}}},
+		},
+		{
+			name:     "empty tool name",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role:  agento11y.RoleAssistant,
+				Parts: []agento11y.Part{agento11y.ToolCallPart(agento11y.ToolCall{ID: "call-1"})},
+			}}},
+		},
+		{
+			name:     "empty tool call id",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role:  agento11y.RoleAssistant,
+				Parts: []agento11y.Part{agento11y.ToolCallPart(agento11y.ToolCall{Name: "lookup"})},
+			}}},
+		},
+		{
+			name:     "whitespace tool call id",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant,
+				Parts: []agento11y.Part{agento11y.ToolCallPart(agento11y.ToolCall{
+					ID: " ", Name: "lookup",
+				})},
+			}}},
+		},
+		{
+			name:     "tool call in user message",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role:  agento11y.RoleUser,
+				Parts: []agento11y.Part{agento11y.ToolCallPart(agento11y.ToolCall{Name: "lookup"})},
+			}}},
+		},
+		{
+			name:     "multiple payload fields",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant,
+				Parts: []agento11y.Part{{
+					Kind:     agento11y.PartKindToolCall,
+					Text:     "extra",
+					ToolCall: &agento11y.ToolCall{Name: "lookup"},
+				}},
+			}}},
+		},
+		{
+			name:     "invalid tool JSON",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant,
+				Parts: []agento11y.Part{agento11y.ToolCallPart(agento11y.ToolCall{
+					ID: "call-1", Name: "lookup", InputJSON: json.RawMessage(`{`),
+				})},
+			}}},
+		},
+		{
+			name:     "duplicate-key tool JSON",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant,
+				Parts: []agento11y.Part{agento11y.ToolCallPart(agento11y.ToolCall{
+					ID: "call-1", Name: "lookup", InputJSON: json.RawMessage(`{"value":1,"\u0076alue":2}`),
+				})},
+			}}},
+		},
+		{
+			name:     "invalid tool result JSON",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1", Name: "lookup", ContentJSON: json.RawMessage(`{`),
+				})},
+			}}},
+		},
+		{
+			name:     "duplicate-key tool result JSON",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1", Name: "lookup", ContentJSON: json.RawMessage(`{"value":1,"value":2}`),
+				})},
+			}}},
+		},
+		{
+			name:     "tool result without correlation",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role:  agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{})},
+			}}},
+		},
+		{
+			name:     "tool result without name",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1",
+				})},
+			}}},
+		},
+		{
+			name:     "tool result without id",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					Name: "lookup",
+				})},
+			}}},
+		},
+		{
+			name:     "whitespace tool result name",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1", Name: " ",
+				})},
+			}}},
+		},
+		{
+			name:     "tool result with both payloads",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1", Name: "lookup", Content: "text", ContentJSON: json.RawMessage(`{"value":1}`),
+				})},
+			}}},
+		},
+		{
+			name:     "tool result without payload",
+			original: []provider.Message{provider.UserText("input")},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1", Name: "lookup",
+				})},
+			}}},
+		},
+		{
+			name: "ambiguous signed and unsigned reasoning",
+			original: []provider.Message{provider.NewAssistantMessage(
+				signedReasoning,
+				provider.ReasoningPart("original"),
+			)},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.ThinkingPart("original")},
+			}}},
+		},
+		{
+			name: "reasoning signature with extra metadata",
+			original: []provider.Message{provider.NewAssistantMessage(provider.ContentPart{
+				Type: provider.ContentPartTypeReasoning,
+				Text: "original",
+				ProviderOptions: provider.ProviderOptions{
+					"anthropic": provider.RawProviderOption{
+						Key: "anthropic", Raw: json.RawMessage(`{"signature":"sig","extra":true}`),
+					},
+				},
+			})},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.ThinkingPart("original")},
+			}}},
+		},
+		{
+			name:     "changed signed reasoning",
+			original: []provider.Message{provider.NewAssistantMessage(signedReasoning)},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleAssistant, Parts: []agento11y.Part{agento11y.ThinkingPart("changed")},
+			}}},
+		},
+		{
+			name: "changed provider tool result",
+			original: []provider.Message{provider.NewToolMessage(provider.ContentPart{
+				Type: provider.ContentPartTypeToolResult, ToolCallID: "call-1", ToolName: "server_tool",
+				ProviderExecuted: true,
+				Output:           &provider.ToolResultOutput{Type: provider.ToolOutputJSON, JSON: json.RawMessage(`{"value":"original"}`)},
+			})},
+			transformed: agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleTool,
+				Parts: []agento11y.Part{agento11y.ToolResultPart(agento11y.ToolResult{
+					ToolCallID: "call-1", Name: "server_tool", ContentJSON: json.RawMessage(`{"value":"changed"}`),
+				})},
+			}}},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := applyTransformedInput(tc.original, tc.transformed)
+			require.ErrorIs(t, err, ErrHookTransformFailed)
+		})
+	}
+}
+
+func TestApplyTransformedInput_DistinguishesLargeJSONIntegers(t *testing.T) {
+	unchangedCall := provider.ToolCallPart("call-1", "lookup", json.RawMessage(`{"value":9007199254740993}`))
+	unchangedTools := []provider.Tool{{
+		Type: provider.ToolTypeFunction, Name: "lookup",
+		InputSchema: json.RawMessage(`{"const":9007199254740993}`),
+	}}
+	_, mappedMessages := messagesToAgento11yWithMediaAndTools(
+		[]provider.Message{provider.NewAssistantMessage(unchangedCall)}, true, unchangedTools,
+	)
+	mappedTools := toolsToAgento11y(unchangedTools)
+	require.Equal(t, `{"value":9007199254740993}`, string(mappedMessages[0].Parts[0].ToolCall.InputJSON))
+	require.Equal(t, `{"const":9007199254740993}`, string(mappedTools[0].InputSchema))
+	unchanged, err := applyTransformedInputWithTools(
+		[]provider.Message{provider.NewAssistantMessage(unchangedCall)}, unchangedTools,
+		agento11y.HookInput{Messages: mappedMessages, Tools: mappedTools},
+	)
+	require.NoError(t, err)
+	require.Equal(t, `{"value":9007199254740993}`, string(unchanged[0].Content[0].Input))
+
+	originalCall := provider.ToolCallPart("call-1", "server_tool", json.RawMessage(`{"value":9007199254740992}`))
+	originalCall.ProviderExecuted = true
+	transformedCall := agento11y.ToolCallPart(agento11y.ToolCall{
+		ID: "call-1", Name: "server_tool", InputJSON: json.RawMessage(`{"value":9007199254740993}`),
+	})
+	transformedCall.Metadata.ProviderType = "server_tool_use"
+
+	_, err = applyTransformedInput(
+		[]provider.Message{provider.NewAssistantMessage(originalCall)},
+		agento11y.HookInput{Messages: []agento11y.Message{{
+			Role: agento11y.RoleAssistant, Parts: []agento11y.Part{transformedCall},
+		}}},
+	)
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+
+	duplicateInput := json.RawMessage(`{"value":1,"value":2}`)
+	require.Equal(t, string(duplicateInput), string(normalizeJSONObject(duplicateInput)))
+	duplicateCall := provider.ToolCallPart("call-2", "server_tool", duplicateInput)
+	duplicateCall.ProviderExecuted = true
+	collapsedCall := agento11y.ToolCallPart(agento11y.ToolCall{
+		ID: "call-2", Name: "server_tool", InputJSON: json.RawMessage(`{"value":2}`),
+	})
+	collapsedCall.Metadata.ProviderType = "server_tool_use"
+	_, err = applyTransformedInput(
+		[]provider.Message{provider.NewAssistantMessage(duplicateCall)},
+		agento11y.HookInput{Messages: []agento11y.Message{{
+			Role: agento11y.RoleAssistant, Parts: []agento11y.Part{collapsedCall},
+		}}},
+	)
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+
+	duplicateSchemaTools := []provider.Tool{{
+		Type: provider.ToolTypeFunction, Name: "lookup",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}}
+	duplicateSchema := toolsToAgento11y(duplicateSchemaTools)[0]
+	duplicateSchema.InputSchema = json.RawMessage(`{"type":"object","type":"array"}`)
+	_, err = applyTransformedTools(duplicateSchemaTools, []agento11y.ToolDefinition{duplicateSchema})
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+
+	originalTools := []provider.Tool{{
+		Type: provider.ToolTypeFunction, Name: "lookup",
+		InputSchema: json.RawMessage(`{"const":9007199254740992}`),
+	}}
+	transformedTool := toolsToAgento11y(originalTools)[0]
+	transformedTool.InputSchema = json.RawMessage(`{"const":9007199254740993}`)
+	_, err = applyTransformedTools(originalTools, []agento11y.ToolDefinition{transformedTool})
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+}
+
+func TestApplyTransformedInput_RequiresExactProviderDiscriminator(t *testing.T) {
+	originalCall := provider.ToolCallPart("call-1", "remote", json.RawMessage(`{"query":"x"}`))
+	originalCall.ProviderExecuted = true
+	originalCall.ProviderOptions = provider.ProviderOptions{
+		"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"type":"mcp-tool-use"}`)},
+	}
+	transformedCall := agento11y.ToolCallPart(agento11y.ToolCall{
+		ID: "call-1", Name: "remote", InputJSON: json.RawMessage(`{"query":"x"}`),
+	})
+	transformedCall.Metadata.ProviderType = "server_tool_use"
+
+	_, err := applyTransformedInput(
+		[]provider.Message{provider.NewAssistantMessage(originalCall)},
+		agento11y.HookInput{Messages: []agento11y.Message{{
+			Role: agento11y.RoleAssistant, Parts: []agento11y.Part{transformedCall},
+		}}},
+	)
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+}
+
+func TestApplyTransformedInput_PreservesAliasedProviderResult(t *testing.T) {
+	tools := []provider.Tool{{
+		Type: provider.ToolTypeProvider, ID: "anthropic.web_fetch_20250910", Name: "fetch_page",
+	}}
+	original := provider.ContentPart{
+		Type: provider.ContentPartTypeToolResult, ToolCallID: "call-1", ToolName: "fetch_page",
+		Output: &provider.ToolResultOutput{Type: provider.ToolOutputJSON, JSON: json.RawMessage(`{"url":"https://example.com"}`)},
+	}
+	_, messages := messagesToAgento11yWithMediaAndTools(
+		[]provider.Message{provider.NewToolMessage(original)}, true, tools,
+	)
+	require.Equal(t, "web_fetch_tool_result", messages[0].Parts[0].Metadata.ProviderType)
+
+	transformed, err := applyTransformedInputWithTools(
+		[]provider.Message{provider.NewToolMessage(original)}, tools,
+		agento11y.HookInput{Messages: messages, Tools: toolsToAgento11y(tools)},
+	)
+	require.NoError(t, err)
+	require.Len(t, transformed, 1)
+	assert.Equal(t, original, transformed[0].Content[0])
+
+	messages[0].Parts[0].Metadata.ProviderType = "tool_result"
+	_, err = applyTransformedInputWithTools(
+		[]provider.Message{provider.NewToolMessage(original)}, tools,
+		agento11y.HookInput{Messages: messages, Tools: toolsToAgento11y(tools)},
+	)
+	require.ErrorIs(t, err, ErrHookTransformFailed)
+}
+
+func TestApplyTransformedInput_RejectsNewProviderSpecificPart(t *testing.T) {
+	call := agento11y.ToolCallPart(agento11y.ToolCall{ID: "call-1", Name: "server_tool"})
+	call.Metadata.ProviderType = "server_tool_use"
+	_, err := applyTransformedInput(
+		[]provider.Message{provider.UserText("input")},
+		agento11y.HookInput{Messages: []agento11y.Message{{
+			Role: agento11y.RoleAssistant, Parts: []agento11y.Part{call},
+		}}},
+	)
+	require.ErrorIs(t, err, ErrHookTransformFailed)
 }
 
 func TestHooksMiddleware_TransformedInput_ModifiedTextRebuilds(t *testing.T) {
-	// When the hook changes the assistant text, the matching algorithm
-	// can't preserve the signature; the message is rebuilt from agento11y parts
-	// (without the signature). This is the documented behavior — the wire
-	// format can't round-trip signatures.
 	originalAssistant := provider.NewAssistantMessage(
 		provider.ContentPart{
 			Type: provider.ContentPartTypeReasoning,
@@ -265,14 +853,12 @@ func TestHooksMiddleware_TransformedInput_ModifiedTextRebuilds(t *testing.T) {
 		},
 	}
 
-	newPrompt := applyTransformedInput(originalPrompt, transformed)
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
 	require.Len(t, newPrompt, 1)
 	require.Len(t, newPrompt[0].Content, 1, "rebuilt message has only the transformed text part")
+	assert.Equal(t, provider.ContentPartTypeText, newPrompt[0].Content[0].Type)
 	assert.Equal(t, "REDACTED answer", newPrompt[0].Content[0].Text)
-	// No reasoning part survived because the rebuild drops thinking parts.
-	for _, p := range newPrompt[0].Content {
-		assert.NotEqual(t, provider.ContentPartTypeReasoning, p.Type)
-	}
 }
 
 func TestHooksMiddleware_TransformedInput_NonAssistantRebuiltFromParts(t *testing.T) {
@@ -284,41 +870,40 @@ func TestHooksMiddleware_TransformedInput_NonAssistantRebuiltFromParts(t *testin
 			{Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("hello (filtered)")}},
 		},
 	}
-	newPrompt := applyTransformedInput(originalPrompt, transformed)
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
 	require.Len(t, newPrompt, 1)
 	assert.Equal(t, provider.RoleUser, newPrompt[0].Role)
 	assert.Equal(t, "hello (filtered)", newPrompt[0].Content[0].Text)
 }
 
-// TestHooksMiddleware_TransformedInput_PreservesSystemMessages guards
-// against a regression where a hook transform silently dropped the
-// original system messages: messagesToAgento11y folds them into a separate
-// HookInput.SystemPrompt field, so a hook response that only modifies user
-// messages comes back with SystemPrompt == "". applyTransformedInput must
-// treat the zero value as "didn't touch the system context" and keep the
-// originals.
-func TestHooksMiddleware_TransformedInput_PreservesSystemMessages(t *testing.T) {
+func TestHooksMiddleware_TransformedInput_DropsOmittedSystemMessages(t *testing.T) {
 	originalPrompt := []provider.Message{
 		provider.NewSystemMessage("you are helpful"),
 		provider.UserText("hello"),
 	}
 	transformed := agento11y.HookInput{
-		// SystemPrompt deliberately empty — the hook only modified the user
-		// message. Without the fix, the resulting prompt has no system.
 		Messages: []agento11y.Message{
 			{Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("hello (filtered)")}},
 		},
 	}
 
-	newPrompt := applyTransformedInput(originalPrompt, transformed)
-	require.Len(t, newPrompt, 2)
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
+	require.Len(t, newPrompt, 1)
+	assert.Equal(t, provider.RoleUser, newPrompt[0].Role)
+	assert.Equal(t, "hello (filtered)", newPrompt[0].Content[0].Text)
+}
 
+func TestHooksMiddleware_TransformedInput_SystemOnlyReplacement(t *testing.T) {
+	newPrompt, err := applyTransformedInput(
+		[]provider.Message{provider.UserText("remove me")},
+		agento11y.HookInput{SystemPrompt: "system only"},
+	)
+	require.NoError(t, err)
+	require.Len(t, newPrompt, 1)
 	assert.Equal(t, provider.RoleSystem, newPrompt[0].Role)
-	require.Len(t, newPrompt[0].Content, 1)
-	assert.Equal(t, "you are helpful", newPrompt[0].Content[0].Text)
-
-	assert.Equal(t, provider.RoleUser, newPrompt[1].Role)
-	assert.Equal(t, "hello (filtered)", newPrompt[1].Content[0].Text)
+	assert.Equal(t, "system only", newPrompt[0].Content[0].Text)
 }
 
 func TestHooksMiddleware_TransformedInput_OverridesSystemPrompt(t *testing.T) {
@@ -335,7 +920,8 @@ func TestHooksMiddleware_TransformedInput_OverridesSystemPrompt(t *testing.T) {
 		},
 	}
 
-	newPrompt := applyTransformedInput(originalPrompt, transformed)
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
 	require.Len(t, newPrompt, 2, "two originals collapsed into one transformed system")
 
 	assert.Equal(t, provider.RoleSystem, newPrompt[0].Role)
@@ -357,12 +943,103 @@ func TestHooksMiddleware_TransformedInput_AddsSystemWhenAbsent(t *testing.T) {
 		},
 	}
 
-	newPrompt := applyTransformedInput(originalPrompt, transformed)
+	newPrompt, err := applyTransformedInput(originalPrompt, transformed)
+	require.NoError(t, err)
 	require.Len(t, newPrompt, 2)
 
 	assert.Equal(t, provider.RoleSystem, newPrompt[0].Role)
 	assert.Equal(t, "you are helpful", newPrompt[0].Content[0].Text)
 	assert.Equal(t, provider.RoleUser, newPrompt[1].Role)
+}
+
+func TestHooksMiddleware_TransformedInput_RemovesTools(t *testing.T) {
+	originalTool := provider.Tool{
+		Type:        provider.ToolTypeFunction,
+		Name:        "lookup",
+		Description: "look up data",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}
+	transformed := agento11y.HookInput{Messages: []agento11y.Message{{
+		Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("filtered")},
+	}}}
+	h := newHooksTestServer(t, agento11y.HookEvaluateResponse{
+		Action:           agento11y.HookActionAllow,
+		TransformedInput: &transformed,
+	})
+	model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
+	client := h.clientWithHooksEnabled()
+	wrapped := middleware.Wrap(middleware.WrapOptions{
+		Model: model,
+		Middleware: []middleware.Middleware{HooksMiddleware(HooksOptions{
+			ClientResolver: func(context.Context) *agento11y.Client { return client },
+		})},
+	})
+
+	_, err := wrapped.DoGenerate(context.Background(), provider.CallOptions{
+		Prompt: []provider.Message{provider.UserText("input")},
+		Tools:  []provider.Tool{originalTool},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, model.lastParams.Tools)
+}
+
+func TestHooksMiddleware_TransformedInput_RejectsUnsatisfiedToolChoice(t *testing.T) {
+	tests := []struct {
+		name       string
+		toolChoice *provider.ToolChoice
+	}{
+		{
+			name:       "required",
+			toolChoice: &provider.ToolChoice{Type: provider.ToolChoiceRequired},
+		},
+		{
+			name:       "selected tool",
+			toolChoice: &provider.ToolChoice{Type: provider.ToolChoiceTool, ToolName: "lookup"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			transformed := agento11y.HookInput{Messages: []agento11y.Message{{
+				Role: agento11y.RoleUser, Parts: []agento11y.Part{agento11y.TextPart("filtered")},
+			}}}
+			h := newHooksTestServer(t, agento11y.HookEvaluateResponse{
+				Action: agento11y.HookActionAllow, TransformedInput: &transformed,
+			})
+			model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
+			wrapped := middleware.Wrap(middleware.WrapOptions{
+				Model: model,
+				Middleware: []middleware.Middleware{HooksMiddleware(HooksOptions{
+					ClientResolver: func(context.Context) *agento11y.Client { return h.clientWithHooksEnabled() },
+				})},
+			})
+
+			_, err := wrapped.DoGenerate(context.Background(), provider.CallOptions{
+				Prompt:     []provider.Message{provider.UserText("input")},
+				Tools:      []provider.Tool{{Type: provider.ToolTypeFunction, Name: "lookup"}},
+				ToolChoice: tc.toolChoice,
+			})
+			require.ErrorIs(t, err, ErrHookTransformFailed)
+			assert.Zero(t, model.generateHit)
+		})
+	}
+}
+
+func TestApplyTransformedTools_PreservesRetainedToolsAndRejectsModifiedTools(t *testing.T) {
+	original := []provider.Tool{
+		{Type: provider.ToolTypeFunction, Name: "first", Description: "first tool"},
+		{Type: provider.ToolTypeFunction, Name: "second", Description: "second tool", Strict: boolPtr(true)},
+	}
+	mapped := toolsToAgento11y(original)
+
+	transformed, err := applyTransformedTools(original, []agento11y.ToolDefinition{mapped[1]})
+	require.NoError(t, err)
+	require.Len(t, transformed, 1)
+	assert.Equal(t, original[1], transformed[0])
+
+	modified := mapped[0]
+	modified.Description = "changed"
+	_, err = applyTransformedTools(original, []agento11y.ToolDefinition{modified})
+	require.ErrorIs(t, err, ErrHookTransformFailed)
 }
 
 func TestBuildHookEvaluateRequest(t *testing.T) {

--- a/middleware/agentobservability/map_request.go
+++ b/middleware/agentobservability/map_request.go
@@ -1,7 +1,9 @@
 package agentobservability
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"strconv"
 	"strings"
 
@@ -24,10 +26,14 @@ const systemPromptSeparator = "\n\n"
 // shape on the Anthropic wire (tool_result blocks live inside user messages
 // but the underlying SDK normalizes them to tool-role messages).
 func messagesToAgento11y(prompt []provider.Message) (string, []agento11y.Message) {
-	return messagesToAgento11yWithMedia(prompt, true)
+	return messagesToAgento11yWithMediaAndTools(prompt, true, nil)
 }
 
-func messagesToAgento11yWithMedia(prompt []provider.Message, includeMedia bool) (string, []agento11y.Message) {
+func messagesToAgento11yWithTools(prompt []provider.Message, tools []provider.Tool) (string, []agento11y.Message) {
+	return messagesToAgento11yWithMediaAndTools(prompt, true, tools)
+}
+
+func messagesToAgento11yWithMediaAndTools(prompt []provider.Message, includeMedia bool, tools []provider.Tool) (string, []agento11y.Message) {
 	if len(prompt) == 0 {
 		return "", nil
 	}
@@ -51,7 +57,7 @@ func messagesToAgento11yWithMedia(prompt []provider.Message, includeMedia bool) 
 			continue
 		}
 
-		normalParts, toolParts := convertMessageParts(msg.Content, includeMedia)
+		normalParts, toolParts := convertMessagePartsWithTools(msg.Content, includeMedia, tools)
 		if len(normalParts) > 0 {
 			out = append(out, agento11y.Message{Role: role, Parts: normalParts})
 		}
@@ -83,9 +89,9 @@ func roleToAgento11y(role provider.Role) (agento11y.Role, bool) {
 // convertMessageParts splits message content parts into (non-tool-result parts,
 // tool-result parts). The caller emits the second slice as its own
 // [agento11y.RoleTool] message when non-empty.
-func convertMessageParts(parts []provider.ContentPart, includeMedia bool) (normal, toolResults []agento11y.Part) {
+func convertMessagePartsWithTools(parts []provider.ContentPart, includeMedia bool, tools []provider.Tool) (normal, toolResults []agento11y.Part) {
 	for i := range parts {
-		part, kind, ok := contentPartToAgento11y(parts[i], includeMedia)
+		part, kind, ok := contentPartToAgento11yWithTools(parts[i], includeMedia, tools)
 		if !ok {
 			continue
 		}
@@ -103,7 +109,7 @@ func convertMessageParts(parts []provider.ContentPart, includeMedia bool) (norma
 // The returned PartKind is also returned so callers can route tool-result
 // parts into a separate message (matching the upstream Anthropic helper's
 // splitting behavior).
-func contentPartToAgento11y(part provider.ContentPart, includeMedia bool) (agento11y.Part, agento11y.PartKind, bool) {
+func contentPartToAgento11yWithTools(part provider.ContentPart, includeMedia bool, tools []provider.Tool) (agento11y.Part, agento11y.PartKind, bool) {
 	switch part.Type {
 	case provider.ContentPartTypeText:
 		if part.Text == "" {
@@ -129,7 +135,12 @@ func contentPartToAgento11y(part provider.ContentPart, includeMedia bool) (agent
 			InputJSON: normalizeJSONObject(part.Input),
 		}
 		out := agento11y.ToolCallPart(call)
-		out.Metadata.ProviderType = providerTypeForToolCall(part)
+		out.Metadata.ProviderType = providerTypeForToolWithDefinitions(
+			part.ProviderExecuted,
+			part.ToolName,
+			anthropicTypeFromOptions(part.ProviderOptions),
+			tools,
+		)
 		return out, agento11y.PartKindToolCall, true
 
 	case provider.ContentPartTypeToolResult:
@@ -140,7 +151,13 @@ func contentPartToAgento11y(part provider.ContentPart, includeMedia bool) (agent
 			IsError:     isErr,
 			ContentJSON: content,
 		})
-		out.Metadata.ProviderType = "tool_result"
+		out.Metadata.ProviderType = providerTypeForToolResult(
+			part.ProviderExecuted,
+			part.ToolName,
+			anthropicTypeFromOptions(part.ProviderOptions),
+			tools,
+			content,
+		)
 		return out, agento11y.PartKindToolResult, true
 
 	case provider.ContentPartTypeFile:
@@ -169,15 +186,108 @@ func contentPartToAgento11y(part provider.ContentPart, includeMedia bool) (agent
 	}
 }
 
-// providerTypeForToolCall recovers the Anthropic provider-type discriminator
-// for tool calls. ProviderExecuted indicates a server-side tool (web_search,
-// code_execution, …); MCP tools are not currently flagged separately at the
-// ai-sdk content layer, so they fall through to "tool_use".
+// providerTypeForToolCall recovers provider-specific tool discriminators
+// retained by the provider-neutral content layer.
 func providerTypeForToolCall(part provider.ContentPart) string {
-	if part.ProviderExecuted {
+	return providerTypeForTool(part.ProviderExecuted, part.ToolName, anthropicTypeFromOptions(part.ProviderOptions))
+}
+
+func providerTypeForTool(providerExecuted bool, toolName, anthropicType string) string {
+	return providerTypeForToolWithDefinitions(providerExecuted, toolName, anthropicType, nil)
+}
+
+func providerTypeForToolWithDefinitions(providerExecuted bool, toolName, anthropicType string, tools []provider.Tool) string {
+	if anthropicType == "mcp-tool-use" {
+		return "mcp_tool_use"
+	}
+	if !providerExecuted {
+		return "tool_use"
+	}
+	providerToolName := resolveAnthropicProviderToolName(tools, toolName)
+	if providerToolName == "" {
+		providerToolName = toolName
+	}
+	switch providerToolName {
+	case "tool_search_tool_regex", "tool_search_tool_bm25":
+		return providerToolName
+	default:
 		return "server_tool_use"
 	}
-	return "tool_use"
+}
+
+func providerTypeForToolResult(providerExecuted bool, toolName, anthropicType string, tools []provider.Tool, result json.RawMessage) string {
+	if anthropicType == "mcp-tool-use" {
+		return "mcp_tool_result"
+	}
+	providerToolName := resolveAnthropicProviderToolName(tools, toolName)
+	resolvedProviderTool := providerToolName != ""
+	if providerToolName == "" {
+		if !providerExecuted {
+			return "tool_result"
+		}
+		providerToolName = toolName
+	}
+	if providerToolName == "code_execution" && (providerExecuted || resolvedProviderTool) {
+		switch resultType := anthropicTypeFromRaw(result); {
+		case resultType == "bash_code_execution_result":
+			return "bash_code_execution_tool_result"
+		case strings.HasPrefix(resultType, "text_editor_code_execution_"):
+			return "text_editor_code_execution_tool_result"
+		}
+	}
+	switch providerToolName {
+	case "web_search":
+		return "web_search_tool_result"
+	case "web_fetch":
+		return "web_fetch_tool_result"
+	case "code_execution":
+		return "code_execution_tool_result"
+	case "tool_search_tool_regex":
+		return "tool_search_tool_regex_tool_result"
+	case "tool_search_tool_bm25":
+		return "tool_search_tool_bm25_tool_result"
+	default:
+		return "tool_result"
+	}
+}
+
+func resolveAnthropicProviderToolName(tools []provider.Tool, toolName string) string {
+	for _, tool := range tools {
+		if tool.Type != provider.ToolTypeProvider || tool.Name != toolName {
+			continue
+		}
+		switch tool.ID {
+		case "anthropic.web_search_20250305", "anthropic.web_search_20260209":
+			return "web_search"
+		case "anthropic.web_fetch_20250910", "anthropic.web_fetch_20260209":
+			return "web_fetch"
+		case "anthropic.code_execution_20250522", "anthropic.code_execution_20250825", "anthropic.code_execution_20260120":
+			return "code_execution"
+		case "anthropic.tool_search_bm25_20251119":
+			return "tool_search_tool_bm25"
+		case "anthropic.tool_search_regex_20251119":
+			return "tool_search_tool_regex"
+		}
+	}
+	return ""
+}
+
+func anthropicTypeFromOptions(opts provider.ProviderOptions) string {
+	raw, ok := readAnthropicRaw(opts)
+	if !ok {
+		return ""
+	}
+	return anthropicTypeFromRaw(raw)
+}
+
+func anthropicTypeFromRaw(raw json.RawMessage) string {
+	var value struct {
+		Type string `json:"type"`
+	}
+	if len(raw) == 0 || json.Unmarshal(raw, &value) != nil {
+		return ""
+	}
+	return value.Type
 }
 
 // toolResultContent serializes a provider.ToolResultOutput into the JSON form
@@ -240,8 +350,8 @@ func normalizeJSONObject(in json.RawMessage) json.RawMessage {
 	if len(in) == 0 {
 		return nil
 	}
-	var v any
-	if err := json.Unmarshal(in, &v); err != nil {
+	v, ok := decodeJSONValue(in)
+	if !ok {
 		return cloneRawJSON(in)
 	}
 	out, err := json.Marshal(v)
@@ -249,6 +359,74 @@ func normalizeJSONObject(in json.RawMessage) json.RawMessage {
 		return cloneRawJSON(in)
 	}
 	return out
+}
+
+func decodeJSONValue(in json.RawMessage) (any, bool) {
+	if !json.Valid(in) {
+		return nil, false
+	}
+	decoder := json.NewDecoder(bytes.NewReader(in))
+	decoder.UseNumber()
+	value, ok := decodeJSONToken(decoder)
+	if !ok {
+		return nil, false
+	}
+	if _, err := decoder.Token(); err != io.EOF {
+		return nil, false
+	}
+	return value, true
+}
+
+func decodeJSONToken(decoder *json.Decoder) (any, bool) {
+	token, err := decoder.Token()
+	if err != nil {
+		return nil, false
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return token, true
+	}
+	switch delimiter {
+	case '{':
+		object := map[string]any{}
+		for decoder.More() {
+			key, err := decoder.Token()
+			if err != nil {
+				return nil, false
+			}
+			name, ok := key.(string)
+			if !ok {
+				return nil, false
+			}
+			if _, duplicate := object[name]; duplicate {
+				return nil, false
+			}
+			value, ok := decodeJSONToken(decoder)
+			if !ok {
+				return nil, false
+			}
+			object[name] = value
+		}
+		if end, err := decoder.Token(); err != nil || end != json.Delim('}') {
+			return nil, false
+		}
+		return object, true
+	case '[':
+		array := []any{}
+		for decoder.More() {
+			value, ok := decodeJSONToken(decoder)
+			if !ok {
+				return nil, false
+			}
+			array = append(array, value)
+		}
+		if end, err := decoder.Token(); err != nil || end != json.Delim(']') {
+			return nil, false
+		}
+		return array, true
+	default:
+		return nil, false
+	}
 }
 
 // toolsToAgento11y converts ai-sdk Tool definitions to agento11y.ToolDefinition.

--- a/middleware/agentobservability/map_request_test.go
+++ b/middleware/agentobservability/map_request_test.go
@@ -176,6 +176,122 @@ func TestMessagesToAgento11y_AssistantServerToolCall(t *testing.T) {
 	assert.Equal(t, "server_tool_use", msgs[0].Parts[0].Metadata.ProviderType)
 }
 
+func TestMessagesToAgento11y_AssistantProviderToolDiscriminators(t *testing.T) {
+	tests := []struct {
+		name string
+		part provider.ContentPart
+		want string
+	}{
+		{
+			name: "tool search",
+			part: provider.ContentPart{Type: provider.ContentPartTypeToolCall, ToolName: "tool_search_tool_bm25", ProviderExecuted: true},
+			want: "tool_search_tool_bm25",
+		},
+		{
+			name: "mcp",
+			part: provider.ContentPart{
+				Type:     provider.ContentPartTypeToolCall,
+				ToolName: "remote_lookup",
+				ProviderOptions: provider.ProviderOptions{
+					"anthropic": provider.RawProviderOption{Key: "anthropic", Raw: json.RawMessage(`{"type":"mcp-tool-use"}`)},
+				},
+			},
+			want: "mcp_tool_use",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, providerTypeForToolCall(tc.part))
+		})
+	}
+}
+
+func TestResolveAnthropicProviderToolName_RequiresExactSupportedID(t *testing.T) {
+	tests := []struct {
+		id   string
+		want string
+	}{
+		{id: "anthropic.web_search_20250305", want: "web_search"},
+		{id: "anthropic.web_search_20260209", want: "web_search"},
+		{id: "anthropic.web_fetch_20250910", want: "web_fetch"},
+		{id: "anthropic.web_fetch_20260209", want: "web_fetch"},
+		{id: "anthropic.code_execution_20250522", want: "code_execution"},
+		{id: "anthropic.code_execution_20250825", want: "code_execution"},
+		{id: "anthropic.code_execution_20260120", want: "code_execution"},
+		{id: "anthropic.tool_search_bm25_20251119", want: "tool_search_tool_bm25"},
+		{id: "anthropic.tool_search_regex_20251119", want: "tool_search_tool_regex"},
+		{id: "anthropic.web_search_not-real"},
+		{id: "anthropic.web_fetch_"},
+		{id: "anthropic.code_execution_99999999"},
+		{id: "anthropic.tool_search_bm25_20251119_extra"},
+		{id: "anthropic.tool_search_regex_20251118"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.id, func(t *testing.T) {
+			got := resolveAnthropicProviderToolName([]provider.Tool{{
+				Type: provider.ToolTypeProvider, ID: tc.id, Name: "alias",
+			}}, "alias")
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMessagesToAgento11y_ProviderToolAliases(t *testing.T) {
+	tools := []provider.Tool{{
+		Type: provider.ToolTypeProvider,
+		ID:   "anthropic.tool_search_regex_20251119",
+		Name: "find_tools",
+	}}
+	call := provider.ToolCallPart("call-1", "find_tools", json.RawMessage(`{}`))
+	call.ProviderExecuted = true
+	result := provider.ContentPart{
+		Type:       provider.ContentPartTypeToolResult,
+		ToolCallID: "call-1",
+		ToolName:   "find_tools",
+		Output:     &provider.ToolResultOutput{Type: provider.ToolOutputJSON, JSON: json.RawMessage(`[]`)},
+	}
+
+	_, messages := messagesToAgento11yWithTools(
+		[]provider.Message{provider.NewAssistantMessage(call), provider.NewToolMessage(result)},
+		tools,
+	)
+	require.Len(t, messages, 2)
+	assert.Equal(t, "tool_search_tool_regex", messages[0].Parts[0].Metadata.ProviderType)
+	assert.Equal(t, "tool_search_tool_regex_tool_result", messages[1].Parts[0].Metadata.ProviderType)
+}
+
+func TestMessagesToAgento11y_CodeExecutionResultDiscriminators(t *testing.T) {
+	tools := []provider.Tool{{
+		Type: provider.ToolTypeProvider, ID: "anthropic.code_execution_20250825", Name: "run_code",
+	}}
+	tests := []struct {
+		name             string
+		result           string
+		providerExecuted bool
+		want             string
+	}{
+		{name: "code execution", result: `{"type":"code_execution_result"}`, providerExecuted: true, want: "code_execution_tool_result"},
+		{name: "bash after response-to-prompt conversion", result: `{"type":"bash_code_execution_result"}`, want: "bash_code_execution_tool_result"},
+		{name: "text editor", result: `{"type":"text_editor_code_execution_create_result"}`, providerExecuted: true, want: "text_editor_code_execution_tool_result"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			part := provider.ContentPart{
+				Type: provider.ContentPartTypeToolResult, ToolCallID: "call-1", ToolName: "run_code",
+				ProviderExecuted: tc.providerExecuted,
+				Output:           &provider.ToolResultOutput{Type: provider.ToolOutputJSON, JSON: json.RawMessage(tc.result)},
+			}
+			_, messages := messagesToAgento11yWithTools(
+				[]provider.Message{provider.NewToolMessage(part)}, tools,
+			)
+			require.Len(t, messages, 1)
+			assert.Equal(t, tc.want, messages[0].Parts[0].Metadata.ProviderType)
+		})
+	}
+}
+
 func TestToolsToAgento11y(t *testing.T) {
 	schema := json.RawMessage(`{"type":"object","properties":{}}`)
 	tools := []provider.Tool{

--- a/middleware/agentobservability/testdata/hooks/transform_preserves_signature/hook_response.json
+++ b/middleware/agentobservability/testdata/hooks/transform_preserves_signature/hook_response.json
@@ -16,6 +16,11 @@
         "role": "assistant",
         "parts": [
           {
+            "kind": "thinking",
+            "thinking": "thinking…",
+            "metadata": {}
+          },
+          {
             "kind": "text",
             "text": "Here is your answer",
             "metadata": {}

--- a/openspec/specs/agent-observability-middleware/spec.md
+++ b/openspec/specs/agent-observability-middleware/spec.md
@@ -393,7 +393,7 @@ For streams, the recording goroutine SHALL select on `ctx.Done()` to avoid block
 5. Branch on the response:
    - **Deny**: return `&HookDenialError{Reason, RuleID, Cause: nil}` to the caller. The inner model SHALL NOT be invoked.
    - **Allow**: invoke the inner model with `params` unchanged.
-   - **TransformedInput**: rebuild `params.Prompt` from the transformed messages (preserving reasoning-block signatures — see "Hooks transform preserves reasoning signatures" below), then invoke the inner model with the new params.
+   - **TransformedInput**: treat the transformed input as an authoritative replacement, rebuild `params.Prompt` and the retained subset of `params.Tools`, and invoke the inner model with the new params. If any returned content cannot be reconstructed without loss or reintroducing omitted content, return `ErrHookTransformFailed` without invoking the model.
 
 #### Scenario: Allow path passes through
 
@@ -419,50 +419,57 @@ For streams, the recording goroutine SHALL select on `ctx.Done()` to avoid block
 - **THEN** the hook call SHALL be cancelled via context deadline
 - **AND** the original request context SHALL NOT be cancelled (only the derived hook-bounded context)
 
-### Requirement: Hooks transform preserves reasoning signatures and system context
+### Requirement: Hook transforms are authoritative and lossless
 
-When `EvaluateHook` returns a `TransformedInput`, `HooksMiddleware` SHALL rebuild `params.Prompt` from the transformed messages using the following algorithm:
+When `EvaluateHook` returns a non-nil `TransformedInput`, `HooksMiddleware` SHALL treat it as an authoritative replacement rather than a partial patch:
 
-1. **System messages**: if `transformed.SystemPrompt` is non-empty, the resulting prompt SHALL begin with a single `provider.Message{Role: RoleSystem}` carrying that text and SHALL NOT carry any original system messages forward. If `transformed.SystemPrompt` is empty (the zero value), the resulting prompt SHALL preserve every original system-role message from `params.Prompt` in their original order. The empty case is treated as "the hook did not touch the system context" because `messagesToAgento11y` produces an empty `SystemPrompt` both when the original prompt has no system messages AND when the hook didn't return one — the two cases are indistinguishable on the underlying SDK wire.
-2. **Reasoning preservation**: build a content-matching index over assistant-role messages in the **original** `params.Prompt` that contain reasoning parts.
-3. For each transformed non-system message:
-   - If role is assistant AND the same concatenated text appears in the index AND has not yet been consumed, use the original message verbatim (preserves `ProviderOptions["anthropic"].signature`).
-   - Otherwise, rebuild the message from the transformed `agento11y` parts.
-4. Non-assistant messages (user, tool) are rebuilt from the transformed parts directly.
+1. A non-empty `SystemPrompt` SHALL become one system message. An empty `SystemPrompt` SHALL carry no original system message forward.
+2. Every transformed message SHALL be rebuilt in returned order. Unknown roles, unsupported part kinds, empty payload parts, and malformed tool payloads SHALL fail with `ErrHookTransformFailed`.
+3. Omitted assistant parts SHALL remain omitted. The middleware SHALL NOT restore an entire original assistant message based only on visible text.
+4. An unchanged reasoning part MAY reuse the exact original part to preserve its provider signature. Matching SHALL use an unambiguous unused reasoning part with identical reasoning text; changed or ambiguous signed reasoning SHALL fail closed.
+5. Unchanged provider-executed tool calls and provider-specific tool results SHALL retain their provider fields only after an exact ID, name, and payload match. A provider-specific part that cannot be matched exactly SHALL fail closed.
+6. Because hook evaluation intentionally excludes media, message-level provider options, text-part provider options, empty reasoning metadata, and other unsupported content, a transform of a prompt containing undisclosed content SHALL fail closed rather than silently dropping or restoring it.
+7. Returned tools SHALL be matched exactly to disclosed original tool definitions. Exact retained tools MAY be preserved or reordered and omitted tools SHALL be removed; new or modified tools that cannot be reconstructed losslessly SHALL fail closed. Removing tools SHALL also fail closed when it leaves a required or specifically named `ToolChoice` unsatisfied.
+8. An empty transform SHALL fail closed. A system-only replacement is valid.
 
-The resulting prompt is the concatenation of (system messages from step 1) + (rebuilt non-system messages from steps 2-4) in that order.
+#### Scenario: Empty transform fails closed
 
-This preserves `ProviderOptions["anthropic"].signature` values on reasoning parts, which do not round-trip through Agent Observability's wire schema, **and** preserves the original system context across hook transforms that only touch user / assistant messages.
-
-#### Scenario: Reasoning signature survives transform
-
-- **GIVEN** an assistant message in `params.Prompt` carrying a reasoning part with `ProviderOptions["anthropic"].signature = "sig-xyz"`
-- **AND** `EvaluateHook` returns a `TransformedInput` that modifies only user messages, leaving the assistant message text unchanged
+- **GIVEN** a non-empty original prompt
+- **AND** `EvaluateHook` returns a non-nil but empty `TransformedInput`
 - **WHEN** the transform is applied
-- **THEN** the resulting `params.Prompt` SHALL contain an assistant message whose reasoning part has `ProviderOptions["anthropic"].signature == "sig-xyz"` byte-equal to the original
+- **THEN** `ErrHookTransformFailed` SHALL be returned
+- **AND** the inner model SHALL NOT be invoked with the original prompt
 
-#### Scenario: Modified assistant text triggers rebuild from agento11y parts
+#### Scenario: Removed assistant parts stay removed
 
-- **GIVEN** an assistant message in `params.Prompt` whose text is "abc"
-- **AND** `EvaluateHook` returns a `TransformedInput` whose corresponding assistant message has text "def"
+- **GIVEN** an original assistant message containing signed reasoning, a tool call, and visible text
+- **AND** the transformed assistant message retains the same reasoning and text but omits the tool call
 - **WHEN** the transform is applied
-- **THEN** the resulting `params.Prompt` SHALL contain an assistant message whose text equals "def"
-- **AND** the original signature (if any) SHALL NOT be carried forward (because the content did not match)
+- **THEN** only the unchanged reasoning part and transformed text SHALL be present
+- **AND** the omitted tool call SHALL NOT be restored
+- **AND** the unchanged reasoning part SHALL retain its original signature
 
-#### Scenario: System messages survive a user-only transform
+#### Scenario: Multimodal transform fails closed
 
-- **GIVEN** `params.Prompt` contains a `provider.Message{Role: RoleSystem}` with text "you are helpful" followed by a user message
-- **AND** `EvaluateHook` returns a `TransformedInput` with `SystemPrompt: ""` and a transformed user message
+- **GIVEN** an original prompt containing text and undisclosed media
+- **AND** the hook returns a transformed text message
 - **WHEN** the transform is applied
-- **THEN** the resulting `params.Prompt` SHALL begin with the original system message verbatim
-- **AND** the inner model SHALL receive a non-empty system context
+- **THEN** `ErrHookTransformFailed` SHALL be returned
+- **AND** the model SHALL NOT receive a prompt with the media silently removed
 
-#### Scenario: Hook overrides system prompt
+#### Scenario: Tool removal is applied
+
+- **GIVEN** the original request exposes a tool
+- **AND** `TransformedInput.Tools` omits that tool
+- **WHEN** the transform is applied
+- **THEN** the model SHALL receive transformed call options without that tool
+
+#### Scenario: Hook replaces system prompt
 
 - **GIVEN** `params.Prompt` contains system messages "be helpful" and "be concise"
 - **AND** `EvaluateHook` returns a `TransformedInput` with `SystemPrompt: "internal-only assistant"`
 - **WHEN** the transform is applied
-- **THEN** the resulting `params.Prompt` SHALL begin with a single system message whose text equals "internal-only assistant"
+- **THEN** the resulting prompt SHALL begin with a single system message whose text equals "internal-only assistant"
 - **AND** the original system messages SHALL NOT appear in the prompt
 
 ### Requirement: Generation-ID DAG context helpers


### PR DESCRIPTION
## Summary

- Treat hook-provided prompts and tools as authoritative replacements instead of partial patches.
- Apply transforms losslessly or fail closed with `ErrHookTransformFailed`, preventing removed or undisclosed request content from being silently restored or dropped.

## Code Changes

- Rebuild transformed messages at part granularity, preserving reasoning signatures and provider-specific tool fields only after exact, unambiguous matches.
- Reject malformed roles and payloads, unsupported metadata, undisclosed media/options, ambiguous reasoning, invalid or duplicate-key JSON, and unsatisfied transformed tool choices.
- Preserve numeric JSON precision and use exact Anthropic provider-tool IDs and configured aliases when reconstructing provider discriminators.

## Tests And Fixtures

- Added regressions for authoritative removal/replacement, signature preservation, malformed transforms, JSON precision and ambiguity, exact tool matching, provider aliases, and generate/stream hook paths.
- Updated hook conformance fixtures and the Agent Observability OpenSpec contract.

## Validation

- `cd middleware/agentobservability && go test ./...`
- `cd middleware/agentobservability && go test -race ./...`
- `cd middleware/agentobservability && go vet ./...`
- `openspec validate --all --strict`

## Stack

- 2 of 3; based on #133.
- Followed by #135. Review this PR as the diff against PR 1, not against `main`.
