### PR TITLE
fix(agentobservability): preserve stream telemetry integrity

### DIFF
--- a/middleware/agentobservability/generation.go
+++ b/middleware/agentobservability/generation.go
@@ -76,10 +76,15 @@ func MapGenerateResult(params provider.CallOptions, result *provider.GenerateRes
 }
 
 func mapGenerateResultWithStart(params provider.CallOptions, result *provider.GenerateResult, ctxInfo ContextInfo, start agento11y.GenerationStart) agento11y.Generation {
-	system, input := messagesToAgento11y(params.Prompt)
+	system, input := messagesToAgento11yWithTools(params.Prompt, params.Tools)
 	controls := controlsFromCallOptions(params)
+	metadata := mergeMetadata(ctxInfo.Metadata, metadataFromProviderOptions(params))
+	if result != nil {
+		metadata = mergeMetadata(metadata, metadataFromUsage(result.Usage))
+	}
 
 	generation := agento11y.Generation{
+		ResponseModel:       start.Model.Name,
 		UserID:              ctxInfo.UserID,
 		AgentName:           ctxInfo.AgentName,
 		AgentVersion:        ctxInfo.AgentVersion,
@@ -93,11 +98,11 @@ func mapGenerateResultWithStart(params provider.CallOptions, result *provider.Ge
 		ThinkingEnabled:     thinkingEnabledFromAnthropic(params.ProviderOptions),
 		ParentGenerationIDs: nil, // filled by recorder seed
 		Tags:                cloneStringMap(ctxInfo.Tags),
-		Metadata:            mergeMetadata(metadataFromProviderOptions(params), ctxInfo.Metadata),
+		Metadata:            metadata,
 	}
 
 	if result != nil {
-		generation.Output = contentToAgento11yOutput(result.Content)
+		generation.Output = contentToAgento11yOutputWithTools(result.Content, params.Tools)
 		generation.Usage = usageToAgento11y(result.Usage)
 		generation.StopReason = finishReasonToAgento11yStop(result.FinishReason)
 		if result.Response != nil {
@@ -144,12 +149,8 @@ func addTransportMetadata(gen *agento11y.Generation, seed generationModelIdentit
 	if gen.Metadata == nil {
 		gen.Metadata = map[string]any{}
 	}
-	if _, ok := gen.Metadata[transportProviderMetadataKey]; !ok {
-		gen.Metadata[transportProviderMetadataKey] = seed.provider
-	}
-	if _, ok := gen.Metadata[transportModelMetadataKey]; !ok {
-		gen.Metadata[transportModelMetadataKey] = seed.model
-	}
+	gen.Metadata[transportProviderMetadataKey] = seed.provider
+	gen.Metadata[transportModelMetadataKey] = seed.model
 }
 
 // mergeMetadata returns the union of two metadata maps. Override entries win

--- a/middleware/agentobservability/generation_test.go
+++ b/middleware/agentobservability/generation_test.go
@@ -173,6 +173,46 @@ func TestMapGenerateResult_CanonicalRoundTrip(t *testing.T) {
 	assert.Empty(t, gen.SpanID, "SpanID is set by recorder")
 }
 
+func TestMapGenerateResult_ServerToolUsageMetadata(t *testing.T) {
+	result := &provider.GenerateResult{Usage: provider.Usage{
+		Raw: json.RawMessage(`{"server_tool_use":{"web_search_requests":2,"web_fetch_requests":1}}`),
+	}}
+	gen := MapGenerateResult(provider.CallOptions{}, result, ContextInfo{Metadata: map[string]any{
+		MetadataServerToolUseTotalRequests: "caller override",
+	}})
+
+	assert.Equal(t, int64(2), gen.Metadata[MetadataServerToolUseWebSearchRequests])
+	assert.Equal(t, int64(1), gen.Metadata[MetadataServerToolUseWebFetchRequests])
+	assert.Equal(t, int64(3), gen.Metadata[MetadataServerToolUseTotalRequests])
+}
+
+func TestMapGenerateResult_ResponseTransportMetadataOverridesCallerValues(t *testing.T) {
+	gen := mapGenerateResultWithStart(
+		provider.CallOptions{},
+		&provider.GenerateResult{Response: &provider.GenerateResponse{ResponseMetadata: provider.ResponseMetadata{
+			Provider: "anthropic", ModelID: "response-model",
+		}}},
+		ContextInfo{Metadata: map[string]any{
+			transportProviderMetadataKey: "spoofed-provider",
+			transportModelMetadataKey:    "spoofed-model",
+		}},
+		agento11y.GenerationStart{Model: agento11y.ModelRef{Provider: "grafana", Name: "requested-model"}},
+	)
+
+	assert.Equal(t, "grafana", gen.Metadata[transportProviderMetadataKey])
+	assert.Equal(t, "requested-model", gen.Metadata[transportModelMetadataKey])
+}
+
+func TestMapGenerateResult_ResponseModelFallsBackToRequestModel(t *testing.T) {
+	gen := mapGenerateResultWithStart(
+		provider.CallOptions{},
+		&provider.GenerateResult{},
+		ContextInfo{},
+		agento11y.GenerationStart{Model: agento11y.ModelRef{Name: "request-model"}},
+	)
+	assert.Equal(t, "request-model", gen.ResponseModel)
+}
+
 func TestMapGenerateResult_NilResult(t *testing.T) {
 	gen := MapGenerateResult(provider.CallOptions{
 		Prompt: []provider.Message{provider.UserText("hi")},

--- a/middleware/agentobservability/map_provider_options.go
+++ b/middleware/agentobservability/map_provider_options.go
@@ -1,6 +1,10 @@
 package agentobservability
 
-import "github.com/grafana/ai-sdk/provider"
+import (
+	"encoding/json"
+
+	"github.com/grafana/ai-sdk/provider"
+)
 
 // Metadata keys mirror the upstream agento11y Anthropic helper so existing
 // dashboards and BigQuery views keep working. Adding new keys is safe;
@@ -10,15 +14,46 @@ const (
 	// thinking budget is recorded in Generation.Metadata. Mirrors
 	// agento11y/go-providers/anthropic's thinkingBudgetMetadataKey constant.
 	MetadataThinkingBudgetTokens = "agento11y.gen_ai.request.thinking.budget_tokens"
+	// MetadataServerToolUseWebSearchRequests records billed Anthropic web searches.
+	MetadataServerToolUseWebSearchRequests = "agento11y.gen_ai.usage.server_tool_use.web_search_requests"
+	// MetadataServerToolUseWebFetchRequests records billed Anthropic web fetches.
+	MetadataServerToolUseWebFetchRequests = "agento11y.gen_ai.usage.server_tool_use.web_fetch_requests"
+	// MetadataServerToolUseTotalRequests records all billed Anthropic server-tool requests.
+	MetadataServerToolUseTotalRequests = "agento11y.gen_ai.usage.server_tool_use.total_requests"
 )
 
-// metadataFromProviderOptions decodes the subset of params.ProviderOptions
-// the middleware needs to surface as agento11y.Generation.Metadata entries.
-//
-// The implementation never imports a provider module; every ProviderOptions
-// value is reached via the opaque RawProviderOption / encoding/json path. New
-// providers' options can be wired in by adding cases here without changing
-// the public API surface.
+// metadataFromUsage extracts provider usage fields that Agent Observability
+// represents as generation metadata.
+func metadataFromUsage(usage provider.Usage) map[string]any {
+	if len(usage.Raw) == 0 {
+		return nil
+	}
+	var raw struct {
+		ServerToolUse struct {
+			WebSearchRequests int64 `json:"web_search_requests"`
+			WebFetchRequests  int64 `json:"web_fetch_requests"`
+		} `json:"server_tool_use"`
+	}
+	if err := json.Unmarshal(usage.Raw, &raw); err != nil {
+		return nil
+	}
+	search := raw.ServerToolUse.WebSearchRequests
+	fetch := raw.ServerToolUse.WebFetchRequests
+	if search < 0 || fetch < 0 || search+fetch == 0 {
+		return nil
+	}
+	out := map[string]any{MetadataServerToolUseTotalRequests: search + fetch}
+	if search > 0 {
+		out[MetadataServerToolUseWebSearchRequests] = search
+	}
+	if fetch > 0 {
+		out[MetadataServerToolUseWebFetchRequests] = fetch
+	}
+	return out
+}
+
+// metadataFromProviderOptions extracts request fields that Agent Observability
+// represents as generation metadata.
 func metadataFromProviderOptions(params provider.CallOptions) map[string]any {
 	out := map[string]any{}
 	if budget := thinkingBudgetFromAnthropic(params.ProviderOptions); budget != nil {

--- a/middleware/agentobservability/map_request.go
+++ b/middleware/agentobservability/map_request.go
@@ -280,6 +280,10 @@ func anthropicTypeFromOptions(opts provider.ProviderOptions) string {
 	return anthropicTypeFromRaw(raw)
 }
 
+func anthropicTypeFromMetadata(metadata provider.ProviderMetadata) string {
+	return anthropicTypeFromRaw(metadata["anthropic"])
+}
+
 func anthropicTypeFromRaw(raw json.RawMessage) string {
 	var value struct {
 		Type string `json:"type"`

--- a/middleware/agentobservability/map_response.go
+++ b/middleware/agentobservability/map_response.go
@@ -19,14 +19,18 @@ const (
 	stopReasonOther        = "other"
 )
 
-// contentToAgento11yOutput converts a generate result's content slice into the
-// single assistant-role agento11y.Message recorded as Generation.Output.
+// contentToAgento11yOutput converts generated content into an assistant message
+// plus tool-role messages for tool results.
 //
 // Mirrors `agento11y/go-providers/anthropic.mapResponseMessages` modulo the
 // tool-result splitting (we do the same split into a separate RoleTool
 // message when the response carries tool-result parts; that path is rare for
 // generate responses but valid for provider-executed multi-turn).
 func contentToAgento11yOutput(content []provider.GenerateContentPart) []agento11y.Message {
+	return contentToAgento11yOutputWithTools(content, nil)
+}
+
+func contentToAgento11yOutputWithTools(content []provider.GenerateContentPart, tools []provider.Tool) []agento11y.Message {
 	if len(content) == 0 {
 		return nil
 	}
@@ -35,7 +39,7 @@ func contentToAgento11yOutput(content []provider.GenerateContentPart) []agento11
 	toolParts := make([]agento11y.Part, 0, 1)
 
 	for i := range content {
-		part, kind, ok := generateContentPartToAgento11y(content[i])
+		part, kind, ok := generateContentPartToAgento11yWithTools(content[i], tools)
 		if !ok {
 			continue
 		}
@@ -65,7 +69,7 @@ func contentToAgento11yOutput(content []provider.GenerateContentPart) []agento11
 	return out
 }
 
-func generateContentPartToAgento11y(part provider.GenerateContentPart) (agento11y.Part, agento11y.PartKind, bool) {
+func generateContentPartToAgento11yWithTools(part provider.GenerateContentPart, tools []provider.Tool) (agento11y.Part, agento11y.PartKind, bool) {
 	switch part.Type {
 	case provider.ContentText:
 		if part.Text == "" {
@@ -88,7 +92,7 @@ func generateContentPartToAgento11y(part provider.GenerateContentPart) (agento11
 			InputJSON: normalizeJSONObject(part.Input),
 		}
 		out := agento11y.ToolCallPart(call)
-		out.Metadata.ProviderType = providerTypeForGenerateToolCall(part)
+		out.Metadata.ProviderType = providerTypeForGenerateToolCall(part, tools)
 		return out, agento11y.PartKindToolCall, true
 
 	case provider.ContentToolResult:
@@ -103,7 +107,13 @@ func generateContentPartToAgento11y(part provider.GenerateContentPart) (agento11
 			IsError:     isErr,
 			ContentJSON: contentJSON,
 		})
-		out.Metadata.ProviderType = "tool_result"
+		out.Metadata.ProviderType = providerTypeForToolResult(
+			part.ProviderExecuted,
+			part.ToolName,
+			anthropicTypeFromMetadata(part.ProviderMetadata),
+			tools,
+			contentJSON,
+		)
 		return out, agento11y.PartKindToolResult, true
 
 	case provider.ContentFile:
@@ -126,11 +136,13 @@ func generateContentPartToAgento11y(part provider.GenerateContentPart) (agento11
 	}
 }
 
-func providerTypeForGenerateToolCall(part provider.GenerateContentPart) string {
-	if part.ProviderExecuted {
-		return "server_tool_use"
-	}
-	return "tool_use"
+func providerTypeForGenerateToolCall(part provider.GenerateContentPart, tools []provider.Tool) string {
+	return providerTypeForToolWithDefinitions(
+		part.ProviderExecuted,
+		part.ToolName,
+		anthropicTypeFromMetadata(part.ProviderMetadata),
+		tools,
+	)
 }
 
 // usageToAgento11y converts provider.Usage into agento11y.TokenUsage. The mapping

--- a/middleware/agentobservability/map_response_test.go
+++ b/middleware/agentobservability/map_response_test.go
@@ -71,6 +71,19 @@ func TestContentToAgento11yOutput_ToolResultSplit(t *testing.T) {
 	assert.Equal(t, agento11y.RoleTool, msgs[1].Role)
 }
 
+func TestContentToAgento11yOutput_CodeExecutionResultSubtype(t *testing.T) {
+	tools := []provider.Tool{{
+		Type: provider.ToolTypeProvider, ID: "anthropic.code_execution_20250825", Name: "run_code",
+	}}
+	messages := contentToAgento11yOutputWithTools([]provider.GenerateContentPart{{
+		Type: provider.ContentToolResult, ToolCallID: "call-1", ToolName: "run_code",
+		ProviderExecuted: true,
+		Result:           json.RawMessage(`{"type":"bash_code_execution_result"}`),
+	}}, tools)
+	require.Len(t, messages, 1)
+	assert.Equal(t, "bash_code_execution_tool_result", messages[0].Parts[0].Metadata.ProviderType)
+}
+
 func TestContentToAgento11yOutput_FileParts(t *testing.T) {
 	pngData := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a}
 	content := []provider.GenerateContentPart{
@@ -249,6 +262,87 @@ func TestUsageToAgento11y(t *testing.T) {
 func TestUsageToAgento11y_Zero(t *testing.T) {
 	got := usageToAgento11y(provider.Usage{})
 	assert.Equal(t, agento11y.TokenUsage{}, got)
+}
+
+func TestMetadataFromUsage_ServerToolUse(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want map[string]any
+	}{
+		{
+			name: "search and fetch",
+			raw:  `{"server_tool_use":{"web_search_requests":2,"web_fetch_requests":1}}`,
+			want: map[string]any{
+				MetadataServerToolUseWebSearchRequests: int64(2),
+				MetadataServerToolUseWebFetchRequests:  int64(1),
+				MetadataServerToolUseTotalRequests:     int64(3),
+			},
+		},
+		{
+			name: "search only",
+			raw:  `{"server_tool_use":{"web_search_requests":1}}`,
+			want: map[string]any{
+				MetadataServerToolUseWebSearchRequests: int64(1),
+				MetadataServerToolUseTotalRequests:     int64(1),
+			},
+		},
+		{name: "zero", raw: `{"server_tool_use":{"web_search_requests":0}}`},
+		{name: "negative", raw: `{"server_tool_use":{"web_search_requests":-1}}`},
+		{name: "malformed", raw: `{`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := metadataFromUsage(provider.Usage{Raw: json.RawMessage(tc.raw)})
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestProviderTypeForGenerateToolCall(t *testing.T) {
+	tests := []struct {
+		name string
+		part provider.GenerateContentPart
+		want string
+	}{
+		{name: "client tool", part: provider.GenerateContentPart{ToolName: "lookup"}, want: "tool_use"},
+		{name: "server tool", part: provider.GenerateContentPart{ToolName: "web_search", ProviderExecuted: true}, want: "server_tool_use"},
+		{name: "tool search", part: provider.GenerateContentPart{ToolName: "tool_search_tool_bm25", ProviderExecuted: true}, want: "tool_search_tool_bm25"},
+		{
+			name: "mcp",
+			part: provider.GenerateContentPart{
+				ToolName:         "remote_lookup",
+				ProviderExecuted: true,
+				ProviderMetadata: provider.ProviderMetadata{"anthropic": json.RawMessage(`{"type":"mcp-tool-use"}`)},
+			},
+			want: "mcp_tool_use",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, providerTypeForGenerateToolCall(tc.part, nil))
+		})
+	}
+}
+
+func TestContentToAgento11yOutput_ProviderToolAliases(t *testing.T) {
+	tools := []provider.Tool{
+		{Type: provider.ToolTypeProvider, ID: "anthropic.tool_search_bm25_20251119", Name: "find_tools"},
+		{Type: provider.ToolTypeProvider, ID: "anthropic.web_search_20250305", Name: "search_docs"},
+	}
+	msgs := contentToAgento11yOutputWithTools([]provider.GenerateContentPart{
+		{Type: provider.ContentToolCall, ToolCallID: "call-1", ToolName: "find_tools", ProviderExecuted: true},
+		{Type: provider.ContentToolResult, ToolCallID: "call-1", ToolName: "find_tools"},
+		{Type: provider.ContentToolResult, ToolCallID: "call-2", ToolName: "search_docs"},
+	}, tools)
+
+	require.Len(t, msgs, 2)
+	assert.Equal(t, "tool_search_tool_bm25", msgs[0].Parts[0].Metadata.ProviderType)
+	require.Len(t, msgs[1].Parts, 2)
+	assert.Equal(t, "tool_search_tool_bm25_tool_result", msgs[1].Parts[0].Metadata.ProviderType)
+	assert.Equal(t, "web_search_tool_result", msgs[1].Parts[1].Metadata.ProviderType)
 }
 
 func TestFinishReasonToAgento11yStop(t *testing.T) {

--- a/middleware/agentobservability/map_stream.go
+++ b/middleware/agentobservability/map_stream.go
@@ -34,18 +34,21 @@ type StreamRecorder struct {
 	// Per-step accumulators. Streams may emit multiple text/reasoning blocks
 	// keyed by an ID (text-start / text-end frame them); we maintain a map so
 	// concurrent IDs accumulate correctly.
-	texts       map[string]*streamTextAcc
-	reasonings  map[string]*streamReasoningAcc
-	toolCalls   map[string]*streamToolCallAcc
-	mediaParts  []agento11y.Part
-	outputOrder []streamOutputRef
-	toolResults []streamToolResultAcc
+	texts                map[string]*streamTextAcc
+	reasonings           map[string]*streamTextAcc
+	toolCalls            []*streamToolCallAcc
+	activeToolCalls      map[string]int
+	mediaParts           []agento11y.Part
+	outputOrder          []streamOutputRef
+	toolResults          []streamToolResultAcc
+	toolResultByIdentity map[streamToolIdentity]int
 
 	// Aggregated stream state.
-	finishReason *provider.FinishReason
-	usage        streamusage.Aggregator
-	responseID   string
-	response     generationModelIdentity
+	finishReason  *provider.FinishReason
+	usage         streamusage.Aggregator
+	responseID    string
+	responseModel string
+	response      generationModelIdentity
 
 	// Error captured from a PartError event mid-stream. The middleware
 	// surfaces this through GenerationRecorder.SetCallError rather than
@@ -56,16 +59,17 @@ type StreamRecorder struct {
 type streamOutputRef struct {
 	partType   provider.StreamPartType
 	id         string
+	toolIndex  int
 	mediaIndex int
+}
+
+type streamToolIdentity struct {
+	id   string
+	name string
 }
 
 type streamTextAcc struct {
 	text strings.Builder
-}
-
-type streamReasoningAcc struct {
-	text      strings.Builder
-	signature string
 }
 
 type streamToolCallAcc struct {
@@ -73,16 +77,20 @@ type streamToolCallAcc struct {
 	name             string
 	input            strings.Builder
 	providerExecuted bool
+	anthropicType    string
 	// final captures the consolidated input when a PartToolCall event fires
 	// (some providers emit the complete input there rather than via deltas).
 	final json.RawMessage
 }
 
 type streamToolResultAcc struct {
-	id      string
-	name    string
-	result  json.RawMessage
-	isError bool
+	id               string
+	name             string
+	result           json.RawMessage
+	isError          bool
+	preliminary      bool
+	providerExecuted bool
+	anthropicType    string
 }
 
 // NewStreamRecorder constructs a StreamRecorder seeded with the
@@ -90,11 +98,12 @@ type streamToolResultAcc struct {
 // folded into Generation() at end-of-stream alongside the accumulated output.
 func NewStreamRecorder(start agento11y.GenerationStart, params provider.CallOptions) *StreamRecorder {
 	return &StreamRecorder{
-		seed:       start,
-		params:     params,
-		texts:      map[string]*streamTextAcc{},
-		reasonings: map[string]*streamReasoningAcc{},
-		toolCalls:  map[string]*streamToolCallAcc{},
+		seed:                 start,
+		params:               params,
+		texts:                map[string]*streamTextAcc{},
+		reasonings:           map[string]*streamTextAcc{},
+		activeToolCalls:      map[string]int{},
+		toolResultByIdentity: map[streamToolIdentity]int{},
 	}
 }
 
@@ -150,62 +159,48 @@ func (r *StreamRecorder) Observe(part provider.StreamPart) {
 
 	case provider.PartReasoningStart:
 		r.ensureReasoning(part.ID)
-		// Some Anthropic reasoning streams attach the signature on the start
-		// event rather than every delta.
-		if sig := anthropicSignatureFromMetadata(part.ProviderMetadata); sig != "" {
-			r.reasonings[part.ID].signature = sig
-		}
 
 	case provider.PartReasoningDelta:
 		acc := r.ensureReasoning(part.ID)
 		acc.text.WriteString(part.Delta)
-		if sig := anthropicSignatureFromMetadata(part.ProviderMetadata); sig != "" {
-			// Multiple deltas may carry the same signature value; we merge
-			// to a single copy on the consolidated reasoning part.
-			acc.signature = sig
-		}
-
-	case provider.PartReasoningEnd:
-		if sig := anthropicSignatureFromMetadata(part.ProviderMetadata); sig != "" {
-			if acc, ok := r.reasonings[part.ID]; ok {
-				acc.signature = sig
-			}
-		}
 
 	case provider.PartToolInputStart:
-		acc := r.ensureToolCall(streamToolCallID(part), part.ToolName)
+		acc := r.startToolCall(streamToolCallID(part), part.ToolName)
 		acc.providerExecuted = acc.providerExecuted || part.ProviderExecuted
+		if anthropicType := anthropicTypeFromMetadata(part.ProviderMetadata); anthropicType != "" {
+			acc.anthropicType = anthropicType
+		}
 
 	case provider.PartToolInputDelta:
-		acc := r.ensureToolCall(streamToolCallID(part), part.ToolName)
+		acc := r.currentToolCall(streamToolCallID(part), part.ToolName)
 		acc.input.WriteString(part.Delta)
 
 	case provider.PartToolInputEnd:
 		// Caller may still emit a PartToolCall with the consolidated input.
 
 	case provider.PartToolCall:
-		acc := r.ensureToolCall(streamToolCallID(part), part.ToolName)
+		acc := r.finishToolCall(streamToolCallID(part), part.ToolName)
 		acc.providerExecuted = acc.providerExecuted || part.ProviderExecuted
+		if anthropicType := anthropicTypeFromMetadata(part.ProviderMetadata); anthropicType != "" {
+			acc.anthropicType = anthropicType
+		}
 		if part.Input != "" {
 			acc.final = json.RawMessage(part.Input)
 		}
 
 	case provider.PartToolResult:
-		r.toolResults = append(r.toolResults, streamToolResultAcc{
-			id:      part.ToolCallID,
-			name:    part.ToolName,
-			result:  part.Result,
-			isError: part.IsError,
-		})
+		r.observeToolResult(part)
 
 	case provider.PartFile:
 		if media, ok := streamFilePartToAgento11y(part, "file"); ok {
+			r.markFirstChunk()
 			r.outputOrder = append(r.outputOrder, streamOutputRef{partType: part.Type, mediaIndex: len(r.mediaParts)})
 			r.mediaParts = append(r.mediaParts, media)
 		}
 
 	case provider.PartReasoningFile:
 		if media, ok := streamFilePartToAgento11y(part, "reasoning_file"); ok {
+			r.markFirstChunk()
 			r.outputOrder = append(r.outputOrder, streamOutputRef{partType: part.Type, mediaIndex: len(r.mediaParts)})
 			r.mediaParts = append(r.mediaParts, media)
 		}
@@ -217,14 +212,64 @@ func (r *StreamRecorder) Observe(part provider.StreamPart) {
 		}
 
 	case provider.PartResponseMeta:
-		r.responseID = part.ResponseID
-		r.response = modelIdentityFromResponse(part.Provider, part.ModelID)
+		if part.ResponseID != "" {
+			r.responseID = part.ResponseID
+		}
+		if part.ModelID != "" {
+			r.responseModel = part.ModelID
+		}
+		if response := modelIdentityFromResponse(part.Provider, part.ModelID); response.complete() {
+			r.response = response
+		}
 
 	case provider.PartError:
 		if part.APICallError != nil {
 			r.callError = part.APICallError
 		}
 	}
+}
+
+func (r *StreamRecorder) markFirstChunk() {
+	if r.firstChunkAt.IsZero() {
+		r.firstChunkAt = time.Now().UTC()
+	}
+}
+
+func (r *StreamRecorder) observeToolResult(part provider.StreamPart) {
+	preliminary := part.Preliminary != nil && *part.Preliminary
+	result := streamToolResultAcc{
+		id:               part.ToolCallID,
+		name:             part.ToolName,
+		result:           cloneRawJSON(part.Result),
+		isError:          part.IsError,
+		preliminary:      preliminary,
+		providerExecuted: part.ProviderExecuted,
+		anthropicType:    anthropicTypeFromMetadata(part.ProviderMetadata),
+	}
+	if part.ToolCallID == "" {
+		r.toolResults = append(r.toolResults, result)
+		return
+	}
+	identity := streamToolIdentity{id: part.ToolCallID, name: part.ToolName}
+	if index, ok := r.toolResultByIdentity[identity]; ok {
+		previous := r.toolResults[index]
+		result.providerExecuted = result.providerExecuted || previous.providerExecuted
+		if result.name == "" {
+			result.name = previous.name
+		}
+		if result.anthropicType == "" {
+			result.anthropicType = previous.anthropicType
+		}
+		r.toolResults[index] = result
+		if !preliminary {
+			delete(r.toolResultByIdentity, identity)
+		}
+		return
+	}
+	if preliminary {
+		r.toolResultByIdentity[identity] = len(r.toolResults)
+	}
+	r.toolResults = append(r.toolResults, result)
 }
 
 func (r *StreamRecorder) ensureText(id string) *streamTextAcc {
@@ -237,11 +282,11 @@ func (r *StreamRecorder) ensureText(id string) *streamTextAcc {
 	return acc
 }
 
-func (r *StreamRecorder) ensureReasoning(id string) *streamReasoningAcc {
+func (r *StreamRecorder) ensureReasoning(id string) *streamTextAcc {
 	if acc, ok := r.reasonings[id]; ok {
 		return acc
 	}
-	acc := &streamReasoningAcc{}
+	acc := &streamTextAcc{}
 	r.reasonings[id] = acc
 	r.outputOrder = append(r.outputOrder, streamOutputRef{partType: provider.PartReasoningStart, id: id})
 	return acc
@@ -257,16 +302,44 @@ func streamToolCallID(part provider.StreamPart) string {
 	return part.ToolCallID
 }
 
-func (r *StreamRecorder) ensureToolCall(id, name string) *streamToolCallAcc {
-	if acc, ok := r.toolCalls[id]; ok {
+func (r *StreamRecorder) startToolCall(id, name string) *streamToolCallAcc {
+	acc := r.appendToolCall(id, name)
+	r.activeToolCalls[id] = len(r.toolCalls) - 1
+	return acc
+}
+
+func (r *StreamRecorder) currentToolCall(id, name string) *streamToolCallAcc {
+	if index, ok := r.activeToolCalls[id]; ok {
+		acc := r.toolCalls[index]
 		if acc.name == "" && name != "" {
 			acc.name = name
 		}
 		return acc
 	}
+	return r.startToolCall(id, name)
+}
+
+func (r *StreamRecorder) finishToolCall(id, name string) *streamToolCallAcc {
+	if index, ok := r.activeToolCalls[id]; ok {
+		delete(r.activeToolCalls, id)
+		acc := r.toolCalls[index]
+		if acc.name == "" || name == "" || acc.name == name {
+			if acc.name == "" {
+				acc.name = name
+			}
+			return acc
+		}
+	}
+	return r.appendToolCall(id, name)
+}
+
+func (r *StreamRecorder) appendToolCall(id, name string) *streamToolCallAcc {
 	acc := &streamToolCallAcc{id: id, name: name}
-	r.toolCalls[id] = acc
-	r.outputOrder = append(r.outputOrder, streamOutputRef{partType: provider.PartToolCall, id: id})
+	r.toolCalls = append(r.toolCalls, acc)
+	r.outputOrder = append(r.outputOrder, streamOutputRef{
+		partType:  provider.PartToolCall,
+		toolIndex: len(r.toolCalls) - 1,
+	})
 	return acc
 }
 
@@ -283,10 +356,15 @@ func (r *StreamRecorder) Generation() agento11y.Generation {
 
 	// Compose Generation from CallOptions identically to MapGenerateResult,
 	// using the accumulated output instead of result.Content.
-	system, input := messagesToAgento11y(r.params.Prompt)
+	system, input := messagesToAgento11yWithTools(r.params.Prompt, r.params.Tools)
 	controls := controlsFromCallOptions(r.params)
 
 	output := r.buildOutput()
+	usage, hasUsage := r.usage.Usage()
+	metadata := mergeMetadata(r.seed.Metadata, metadataFromProviderOptions(r.params))
+	if hasUsage {
+		metadata = mergeMetadata(metadata, metadataFromUsage(usage))
+	}
 
 	gen := agento11y.Generation{
 		UserID:              r.seed.UserID,
@@ -303,14 +381,18 @@ func (r *StreamRecorder) Generation() agento11y.Generation {
 		ToolChoice:          controls.ToolChoice,
 		ThinkingEnabled:     thinkingEnabledFromAnthropic(r.params.ProviderOptions),
 		Tags:                cloneStringMap(r.seed.Tags),
-		Metadata:            mergeMetadata(metadataFromProviderOptions(r.params), r.seed.Metadata),
+		Metadata:            metadata,
 	}
 	if r.responseID != "" {
 		gen.ResponseID = r.responseID
 	}
+	gen.ResponseModel = r.seed.Model.Name
+	if r.responseModel != "" {
+		gen.ResponseModel = r.responseModel
+	}
 	applyModelIdentity(&gen, modelIdentityFromStart(r.seed), r.response)
 
-	if usage, ok := r.usage.Usage(); ok {
+	if hasUsage {
 		gen.Usage = usageToAgento11y(usage)
 	}
 	if r.finishReason != nil {
@@ -344,7 +426,7 @@ func (r *StreamRecorder) buildOutput() []agento11y.Message {
 			parts = append(parts, agento11y.TextPart(acc.text.String()))
 
 		case provider.PartToolCall:
-			acc := r.toolCalls[ref.id]
+			acc := r.toolCalls[ref.toolIndex]
 			var input json.RawMessage
 			if len(acc.final) > 0 {
 				input = normalizeJSONObject(acc.final)
@@ -356,11 +438,12 @@ func (r *StreamRecorder) buildOutput() []agento11y.Message {
 				Name:      acc.name,
 				InputJSON: input,
 			})
-			if acc.providerExecuted {
-				part.Metadata.ProviderType = "server_tool_use"
-			} else {
-				part.Metadata.ProviderType = "tool_use"
-			}
+			part.Metadata.ProviderType = providerTypeForToolWithDefinitions(
+				acc.providerExecuted,
+				acc.name,
+				acc.anthropicType,
+				r.params.Tools,
+			)
 			parts = append(parts, part)
 
 		case provider.PartFile, provider.PartReasoningFile:
@@ -377,13 +460,30 @@ func (r *StreamRecorder) buildOutput() []agento11y.Message {
 	}
 
 	for _, result := range r.toolResults {
+		if result.preliminary {
+			continue
+		}
 		out := agento11y.ToolResultPart(agento11y.ToolResult{
 			ToolCallID:  result.id,
 			Name:        result.name,
 			IsError:     result.isError,
 			ContentJSON: result.result,
 		})
-		out.Metadata.ProviderType = "tool_result"
+		providerExecuted := result.providerExecuted
+		anthropicType := result.anthropicType
+		if call, ok := r.matchToolCall(result.id, result.name); ok {
+			providerExecuted = providerExecuted || call.providerExecuted
+			if anthropicType == "" {
+				anthropicType = call.anthropicType
+			}
+		}
+		out.Metadata.ProviderType = providerTypeForToolResult(
+			providerExecuted,
+			result.name,
+			anthropicType,
+			r.params.Tools,
+			result.result,
+		)
 		output = append(output, agento11y.Message{
 			Role:  agento11y.RoleTool,
 			Name:  result.name,
@@ -397,46 +497,29 @@ func (r *StreamRecorder) buildOutput() []agento11y.Message {
 	return output
 }
 
-// isPayloadPart returns true for stream events that represent observable
-// output (deltas, the final completion event, errors). Bookkeeping events
-// such as PartStreamStart or PartResponseMeta are excluded so first-token
-// timestamps reflect actual output emission.
+func (r *StreamRecorder) matchToolCall(id, name string) (*streamToolCallAcc, bool) {
+	var match *streamToolCallAcc
+	for _, call := range r.toolCalls {
+		if call.id != id || call.name != name {
+			continue
+		}
+		if match != nil {
+			return nil, false
+		}
+		match = call
+	}
+	return match, match != nil
+}
+
 func isPayloadPart(part provider.StreamPart) bool {
 	switch part.Type {
-	case provider.PartTextDelta,
-		provider.PartReasoningDelta,
-		provider.PartToolInputDelta,
-		provider.PartToolCall,
-		provider.PartToolResult,
-		provider.PartFile,
-		provider.PartReasoningFile,
-		provider.PartFinish,
-		provider.PartError:
+	case provider.PartTextDelta, provider.PartReasoningDelta, provider.PartToolInputDelta:
+		return part.Delta != ""
+	case provider.PartToolCall:
 		return true
 	default:
 		return false
 	}
-}
-
-// anthropicSignatureFromMetadata extracts the cryptographic signature
-// Anthropic attaches to reasoning blocks. The signature lives at
-// metadata["anthropic"].signature in the provider wire form; consumers must
-// preserve it byte-for-byte across recording roundtrips.
-func anthropicSignatureFromMetadata(meta provider.ProviderMetadata) string {
-	if len(meta) == 0 {
-		return ""
-	}
-	raw, ok := meta["anthropic"]
-	if !ok || len(raw) == 0 {
-		return ""
-	}
-	var probe struct {
-		Signature string `json:"signature"`
-	}
-	if err := json.Unmarshal(raw, &probe); err != nil {
-		return ""
-	}
-	return probe.Signature
 }
 
 func cloneStringSlice(in []string) []string {

--- a/middleware/agentobservability/map_stream_test.go
+++ b/middleware/agentobservability/map_stream_test.go
@@ -76,6 +76,38 @@ func TestStreamRecorder_UsageAggregatesEveryPart(t *testing.T) {
 	assert.Equal(t, int64(outputReasoning), usage.ReasoningTokens)
 }
 
+func TestStreamRecorder_ServerToolUsageMetadata(t *testing.T) {
+	r := newRecorderForStreamTest()
+	r.Observe(provider.StreamPart{Type: provider.PartFinish, Usage: &provider.Usage{
+		Raw: json.RawMessage(`{"server_tool_use":{"web_search_requests":1,"web_fetch_requests":2}}`),
+	}})
+
+	gen := r.Generation()
+	assert.Equal(t, int64(1), gen.Metadata[MetadataServerToolUseWebSearchRequests])
+	assert.Equal(t, int64(2), gen.Metadata[MetadataServerToolUseWebFetchRequests])
+	assert.Equal(t, int64(3), gen.Metadata[MetadataServerToolUseTotalRequests])
+}
+
+func TestStreamRecorder_ServerToolUsageMetadataOverridesSeed(t *testing.T) {
+	r := NewStreamRecorder(agento11y.GenerationStart{
+		Metadata: map[string]any{
+			MetadataServerToolUseWebSearchRequests: "caller search",
+			MetadataServerToolUseWebFetchRequests:  "caller fetch",
+			MetadataServerToolUseTotalRequests:     "caller total",
+			"caller.key":                           "preserved",
+		},
+	}, provider.CallOptions{})
+	r.Observe(provider.StreamPart{Type: provider.PartFinish, Usage: &provider.Usage{
+		Raw: json.RawMessage(`{"server_tool_use":{"web_search_requests":1,"web_fetch_requests":2}}`),
+	}})
+
+	gen := r.Generation()
+	assert.Equal(t, int64(1), gen.Metadata[MetadataServerToolUseWebSearchRequests])
+	assert.Equal(t, int64(2), gen.Metadata[MetadataServerToolUseWebFetchRequests])
+	assert.Equal(t, int64(3), gen.Metadata[MetadataServerToolUseTotalRequests])
+	assert.Equal(t, "preserved", gen.Metadata["caller.key"])
+}
+
 func TestStreamRecorder_FilePartsPreserveObservedOrder(t *testing.T) {
 	r := newRecorderForStreamTest()
 	r.Observe(provider.StreamPart{
@@ -119,27 +151,11 @@ func TestStreamRecorder_FilePartsPreserveObservedOrder(t *testing.T) {
 	assert.Equal(t, "reasoning_file", gen.Output[0].Parts[4].Metadata.ProviderType)
 }
 
-func TestStreamRecorder_TextReasoningSignature(t *testing.T) {
+func TestStreamRecorder_TextAndReasoning(t *testing.T) {
 	r := newRecorderForStreamTest()
 	r.Observe(provider.StreamPart{Type: provider.PartReasoningStart, ID: "r0"})
 	r.Observe(provider.StreamPart{Type: provider.PartReasoningDelta, ID: "r0", Delta: "let me "})
-	// Signature on later deltas — should be merged into the consolidated reasoning part.
-	r.Observe(provider.StreamPart{
-		Type:  provider.PartReasoningDelta,
-		ID:    "r0",
-		Delta: "think",
-		ProviderMetadata: provider.ProviderMetadata{
-			"anthropic": json.RawMessage(`{"signature":"sig-abc"}`),
-		},
-	})
-	r.Observe(provider.StreamPart{
-		Type: provider.PartReasoningDelta,
-		ID:   "r0",
-		// Same signature again — recorder dedupes to one copy.
-		ProviderMetadata: provider.ProviderMetadata{
-			"anthropic": json.RawMessage(`{"signature":"sig-abc"}`),
-		},
-	})
+	r.Observe(provider.StreamPart{Type: provider.PartReasoningDelta, ID: "r0", Delta: "think"})
 	r.Observe(provider.StreamPart{Type: provider.PartReasoningEnd, ID: "r0"})
 	r.Observe(provider.StreamPart{Type: provider.PartTextStart, ID: "t0"})
 	r.Observe(provider.StreamPart{Type: provider.PartTextDelta, ID: "t0", Delta: "answer"})
@@ -222,6 +238,124 @@ func TestStreamRecorder_ProviderExecutedToolCall(t *testing.T) {
 	assert.Equal(t, "server_tool_use", call.Metadata.ProviderType)
 }
 
+func TestStreamRecorder_ProviderExecutedToolDiscriminators(t *testing.T) {
+	tests := []struct {
+		name string
+		part provider.StreamPart
+		want string
+	}{
+		{
+			name: "tool search",
+			part: provider.StreamPart{Type: provider.PartToolCall, ToolCallID: "tc-1", ToolName: "tool_search_tool_regex", ProviderExecuted: true},
+			want: "tool_search_tool_regex",
+		},
+		{
+			name: "mcp",
+			part: provider.StreamPart{
+				Type:             provider.PartToolCall,
+				ToolCallID:       "tc-1",
+				ToolName:         "remote_lookup",
+				ProviderExecuted: true,
+				ProviderMetadata: provider.ProviderMetadata{"anthropic": json.RawMessage(`{"type":"mcp-tool-use"}`)},
+			},
+			want: "mcp_tool_use",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := newRecorderForStreamTest()
+			r.Observe(tc.part)
+			gen := r.Generation()
+			require.Len(t, gen.Output, 1)
+			require.Len(t, gen.Output[0].Parts, 1)
+			assert.Equal(t, tc.want, gen.Output[0].Parts[0].Metadata.ProviderType)
+		})
+	}
+}
+
+func TestStreamRecorder_ClonesToolProviderMetadata(t *testing.T) {
+	metadata := provider.ProviderMetadata{
+		"anthropic": json.RawMessage(`{"type":"mcp-tool-use"}`),
+	}
+	r := newRecorderForStreamTest()
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolCall, ToolCallID: "call-1", ToolName: "remote", ProviderExecuted: true,
+		ProviderMetadata: metadata,
+	})
+	metadata["anthropic"] = json.RawMessage(`{"type":"other"}`)
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolCall, ToolCallID: "call-1", ToolName: "remote", ProviderExecuted: true,
+		ProviderMetadata: provider.ProviderMetadata{"anthropic": json.RawMessage(`{"serverName":"remote"}`)},
+	})
+
+	gen := r.Generation()
+	require.Len(t, gen.Output, 1)
+	assert.Equal(t, "mcp_tool_use", gen.Output[0].Parts[0].Metadata.ProviderType)
+}
+
+func TestStreamRecorder_ToolMetadataRequiresExactInvocationIdentity(t *testing.T) {
+	r := newRecorderForStreamTest()
+	mcpMetadata := provider.ProviderMetadata{
+		"anthropic": json.RawMessage(`{"type":"mcp-tool-use"}`),
+	}
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolCall, ToolCallID: "same", ToolName: "remote", Input: `{"step":1}`,
+		ProviderMetadata: mcpMetadata,
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolInputStart, ID: "same", ToolName: "lookup",
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolInputDelta, ID: "same", Delta: `{"step":2}`,
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolCall, ToolCallID: "same", ToolName: "lookup", Input: `{"step":2}`,
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolResult, ToolCallID: "same", ToolName: "lookup", Result: json.RawMessage(`{"ok":true}`),
+	})
+
+	gen := r.Generation()
+	require.Len(t, gen.Output, 2)
+	require.Len(t, gen.Output[0].Parts, 2)
+	assert.Equal(t, "remote", gen.Output[0].Parts[0].ToolCall.Name)
+	assert.JSONEq(t, `{"step":1}`, string(gen.Output[0].Parts[0].ToolCall.InputJSON))
+	assert.Equal(t, "mcp_tool_use", gen.Output[0].Parts[0].Metadata.ProviderType)
+	assert.Equal(t, "lookup", gen.Output[0].Parts[1].ToolCall.Name)
+	assert.JSONEq(t, `{"step":2}`, string(gen.Output[0].Parts[1].ToolCall.InputJSON))
+	assert.Equal(t, "tool_use", gen.Output[0].Parts[1].Metadata.ProviderType)
+	assert.Equal(t, "tool_result", gen.Output[1].Parts[0].Metadata.ProviderType)
+}
+
+func TestStreamRecorder_ProviderToolAliasDiscriminators(t *testing.T) {
+	r := NewStreamRecorder(agento11y.GenerationStart{}, provider.CallOptions{Tools: []provider.Tool{
+		{Type: provider.ToolTypeProvider, ID: "anthropic.tool_search_regex_20251119", Name: "find_tools"},
+		{Type: provider.ToolTypeProvider, ID: "anthropic.web_fetch_20250910", Name: "fetch_page"},
+		{Type: provider.ToolTypeProvider, ID: "anthropic.code_execution_20250825", Name: "run_code"},
+	}})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolCall, ToolCallID: "call-1", ToolName: "find_tools", ProviderExecuted: true,
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolResult, ToolCallID: "call-1", ToolName: "find_tools",
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolResult, ToolCallID: "call-2", ToolName: "fetch_page",
+	})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartToolResult, ToolCallID: "call-3", ToolName: "run_code", ProviderExecuted: true,
+		Result: json.RawMessage(`{"type":"text_editor_code_execution_create_result"}`),
+	})
+
+	gen := r.Generation()
+	require.Len(t, gen.Output, 4)
+	assert.Equal(t, "tool_search_tool_regex", gen.Output[0].Parts[0].Metadata.ProviderType)
+	assert.Equal(t, "tool_search_tool_regex_tool_result", gen.Output[1].Parts[0].Metadata.ProviderType)
+	assert.Equal(t, "web_fetch_tool_result", gen.Output[2].Parts[0].Metadata.ProviderType)
+	assert.Equal(t, "text_editor_code_execution_tool_result", gen.Output[3].Parts[0].Metadata.ProviderType)
+}
+
 func TestStreamRecorder_ToolResult(t *testing.T) {
 	r := newRecorderForStreamTest()
 	r.Observe(provider.StreamPart{
@@ -245,6 +379,47 @@ func TestStreamRecorder_ToolResult(t *testing.T) {
 	assert.JSONEq(t, `"sunny"`, string(result.ToolResult.ContentJSON))
 }
 
+func TestStreamRecorder_ToolResult_CoalescesPreliminaryResults(t *testing.T) {
+	r := newRecorderForStreamTest()
+	preliminary := true
+	r.Observe(provider.StreamPart{
+		Type:        provider.PartToolResult,
+		ToolCallID:  "tc-1",
+		ToolName:    "generate_image",
+		Result:      json.RawMessage(`{"url":"preview"}`),
+		Preliminary: &preliminary,
+	})
+	assert.Nil(t, r.Generation().Output)
+
+	r.Observe(provider.StreamPart{
+		Type:       provider.PartToolResult,
+		ToolCallID: "tc-1",
+		ToolName:   "generate_image",
+		Result:     json.RawMessage(`{"url":"final"}`),
+	})
+	gen := r.Generation()
+	require.Len(t, gen.Output, 1)
+	require.Len(t, gen.Output[0].Parts, 1)
+	assert.JSONEq(t, `{"url":"final"}`, string(gen.Output[0].Parts[0].ToolResult.ContentJSON))
+}
+
+func TestStreamRecorder_ToolResult_PreservesRepeatedFinalResults(t *testing.T) {
+	r := newRecorderForStreamTest()
+	for _, result := range []string{`{"step":1}`, `{"step":2}`} {
+		r.Observe(provider.StreamPart{
+			Type:       provider.PartToolResult,
+			ToolCallID: "tc-1",
+			ToolName:   "lookup",
+			Result:     json.RawMessage(result),
+		})
+	}
+
+	gen := r.Generation()
+	require.Len(t, gen.Output, 2)
+	assert.JSONEq(t, `{"step":1}`, string(gen.Output[0].Parts[0].ToolResult.ContentJSON))
+	assert.JSONEq(t, `{"step":2}`, string(gen.Output[1].Parts[0].ToolResult.ContentJSON))
+}
+
 func TestStreamRecorder_ToolCallFinalEvent(t *testing.T) {
 	// Some providers send PartToolCall with the consolidated Input instead of
 	// per-delta accumulation.
@@ -262,14 +437,41 @@ func TestStreamRecorder_ToolCallFinalEvent(t *testing.T) {
 }
 
 func TestStreamRecorder_FirstChunkAt(t *testing.T) {
-	r := newRecorderForStreamTest()
-	assert.True(t, r.FirstChunkAt().IsZero(), "no observations yet")
+	nonPayload := []provider.StreamPart{
+		{Type: provider.PartStreamStart},
+		{Type: provider.PartResponseMeta},
+		{Type: provider.PartTextDelta},
+		{Type: provider.PartToolResult},
+		{Type: provider.PartFile},
+		{Type: provider.PartReasoningFile},
+		{Type: provider.PartFinish},
+		{Type: provider.PartError},
+	}
+	for _, part := range nonPayload {
+		r := newRecorderForStreamTest()
+		r.Observe(part)
+		assert.True(t, r.FirstChunkAt().IsZero(), "%s must not start the clock", part.Type)
+	}
 
-	r.Observe(provider.StreamPart{Type: provider.PartStreamStart})
-	assert.True(t, r.FirstChunkAt().IsZero(), "bookkeeping events do not start the clock")
-
-	r.Observe(provider.StreamPart{Type: provider.PartTextDelta, ID: "t0", Delta: "x"})
-	assert.False(t, r.FirstChunkAt().IsZero(), "payload event starts the clock")
+	payload := []provider.StreamPart{
+		{Type: provider.PartTextDelta, Delta: "x"},
+		{Type: provider.PartReasoningDelta, Delta: "x"},
+		{Type: provider.PartToolInputDelta, Delta: "{"},
+		{Type: provider.PartToolCall},
+		{
+			Type: provider.PartFile, MediaType: "image/png",
+			Data: &provider.StreamFileData{URL: "https://example.com/image.png"},
+		},
+		{
+			Type: provider.PartReasoningFile, MediaType: "image/png",
+			Data: &provider.StreamFileData{URL: "https://example.com/reasoning.png"},
+		},
+	}
+	for _, part := range payload {
+		r := newRecorderForStreamTest()
+		r.Observe(part)
+		assert.False(t, r.FirstChunkAt().IsZero(), "%s must start the clock", part.Type)
+	}
 }
 
 func TestStreamRecorder_ErrorMidStream(t *testing.T) {
@@ -348,6 +550,14 @@ func TestStreamRecorder_ResponseMetadataModelIdentity(t *testing.T) {
 			wantProvider:     "anthropic",
 			wantModel:        "claude-sonnet-4-5-20250929",
 		},
+		{
+			name:             "missing response model uses request model",
+			seedProvider:     "anthropic",
+			seedModel:        "claude-sonnet-4-5-sonnet",
+			responseProvider: "anthropic",
+			wantProvider:     "anthropic",
+			wantModel:        "claude-sonnet-4-5-sonnet",
+		},
 	}
 
 	for _, tc := range tests {
@@ -367,6 +577,11 @@ func TestStreamRecorder_ResponseMetadataModelIdentity(t *testing.T) {
 			assert.Equal(t, tc.wantProvider, gen.Model.Provider)
 			assert.Equal(t, tc.wantModel, gen.Model.Name)
 			assert.Equal(t, "resp-1", gen.ResponseID)
+			wantResponseModel := tc.responseModel
+			if wantResponseModel == "" {
+				wantResponseModel = tc.seedModel
+			}
+			assert.Equal(t, wantResponseModel, gen.ResponseModel)
 			if tc.wantTransportMetadata {
 				require.NotNil(t, gen.Metadata)
 				assert.Equal(t, tc.seedProvider, gen.Metadata[transportProviderMetadataKey])
@@ -379,41 +594,43 @@ func TestStreamRecorder_ResponseMetadataModelIdentity(t *testing.T) {
 	}
 }
 
+func TestStreamRecorder_ResponseTransportMetadataOverridesCallerValues(t *testing.T) {
+	r := NewStreamRecorder(agento11y.GenerationStart{
+		Model: agento11y.ModelRef{Provider: "grafana", Name: "requested-model"},
+		Metadata: map[string]any{
+			transportProviderMetadataKey: "spoofed-provider",
+			transportModelMetadataKey:    "spoofed-model",
+		},
+	}, provider.CallOptions{})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartResponseMeta, Provider: "anthropic", ModelID: "response-model",
+	})
+
+	gen := r.Generation()
+	assert.Equal(t, "grafana", gen.Metadata[transportProviderMetadataKey])
+	assert.Equal(t, "requested-model", gen.Metadata[transportModelMetadataKey])
+}
+
+func TestStreamRecorder_ResponseMetadataAccumulatesWithoutErasing(t *testing.T) {
+	r := NewStreamRecorder(agento11y.GenerationStart{
+		Model: agento11y.ModelRef{Provider: "grafana", Name: "requested-model"},
+	}, provider.CallOptions{})
+	r.Observe(provider.StreamPart{
+		Type: provider.PartResponseMeta, ResponseID: "response-1", Provider: "anthropic", ModelID: "response-model",
+	})
+	r.Observe(provider.StreamPart{Type: provider.PartResponseMeta, Provider: "grafana"})
+
+	gen := r.Generation()
+	assert.Equal(t, "response-1", gen.ResponseID)
+	assert.Equal(t, "response-model", gen.ResponseModel)
+	assert.Equal(t, "anthropic", gen.Model.Provider)
+	assert.Equal(t, "response-model", gen.Model.Name)
+}
+
 func TestStreamRecorder_NilSafe(t *testing.T) {
 	var r *StreamRecorder
 	r.Observe(provider.StreamPart{Type: provider.PartTextDelta})
 	assert.True(t, r.FirstChunkAt().IsZero())
 	assert.Nil(t, r.CallError())
 	assert.Equal(t, agento11y.Generation{}, r.Generation())
-}
-
-func TestAnthropicSignatureFromMetadata(t *testing.T) {
-	tests := []struct {
-		name string
-		meta provider.ProviderMetadata
-		want string
-	}{
-		{"nil", nil, ""},
-		{"no anthropic key", provider.ProviderMetadata{"other": json.RawMessage(`{}`)}, ""},
-		{
-			"signature present",
-			provider.ProviderMetadata{"anthropic": json.RawMessage(`{"signature":"sig-1"}`)},
-			"sig-1",
-		},
-		{
-			"no signature in object",
-			provider.ProviderMetadata{"anthropic": json.RawMessage(`{"other":"x"}`)},
-			"",
-		},
-		{
-			"malformed JSON returns empty",
-			provider.ProviderMetadata{"anthropic": json.RawMessage(`{garbage`)},
-			"",
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, anthropicSignatureFromMetadata(tc.meta))
-		})
-	}
 }

--- a/middleware/agentobservability/recording.go
+++ b/middleware/agentobservability/recording.go
@@ -128,9 +128,8 @@ func wrapRecordingStream(ctx context.Context, opts RecordingOptions, p middlewar
 
 // runStreamTee shuttles parts from the inner-model stream to the consumer
 // while observing each event through the StreamRecorder. It finalizes the
-// recorder (SetResult and, for stream errors, SetCallError) once the upstream
-// channel closes or the request context cancels. After cancellation, upstream
-// is drained on a best-effort basis to release the producer goroutine.
+// recorder (SetResult and, for stream errors or cancellation, SetCallError)
+// once the upstream channel closes or the request context cancels.
 func runStreamTee(
 	ctx context.Context,
 	upstream <-chan provider.StreamPart,
@@ -142,13 +141,13 @@ func runStreamTee(
 	defer recorder.End()
 	defer close(tee)
 
-	consumerDisconnected := false
-
+	canceled := false
 streamLoop:
 	for {
 		select {
 		case part, ok := <-upstream:
 			if !ok {
+				canceled = ctx.Err() != nil
 				break streamLoop
 			}
 			streamRec.Observe(part)
@@ -156,22 +155,21 @@ streamLoop:
 			select {
 			case tee <- part:
 			case <-ctx.Done():
-				consumerDisconnected = true
+				canceled = true
 				break streamLoop
 			}
 		case <-ctx.Done():
-			consumerDisconnected = true
+			canceled = true
 			break streamLoop
 		}
 	}
 
-	if consumerDisconnected {
-		go drainProviderStream(upstream)
-	}
 	if first := streamRec.FirstChunkAt(); !first.IsZero() {
 		recorder.SetFirstTokenAt(first)
 	}
-	if callErr := streamRec.CallError(); callErr != nil {
+	if canceled {
+		recorder.SetCallError(ctx.Err())
+	} else if callErr := streamRec.CallError(); callErr != nil {
 		recorder.SetCallError(callErr)
 	}
 
@@ -188,11 +186,6 @@ streamLoop:
 		gen.AgentVersion = ctxInfo.AgentVersion
 	}
 	recorder.SetResult(gen, nil)
-}
-
-func drainProviderStream(upstream <-chan provider.StreamPart) {
-	for range upstream {
-	}
 }
 
 // resolveClient returns the *agento11y.Client for the request, treating a

--- a/middleware/agentobservability/recording_test.go
+++ b/middleware/agentobservability/recording_test.go
@@ -335,9 +335,62 @@ func TestRecordingMiddleware_StreamPartError_RecordsUsageAndCallError(t *testing
 	assert.Equal(t, "170", usage["total_tokens"])
 }
 
-func TestRecordingMiddleware_StreamConsumerAbandons_DrainsAndRecords(t *testing.T) {
+func TestRecordingMiddleware_StreamCancellationTakesPrecedenceOverPartError(t *testing.T) {
 	env := testkit.NewEnv(t)
-	model := &mockLanguageModel{provider_: "anthropic", modelID: "claude"}
+	model := &mockLanguageModel{
+		provider_: "anthropic",
+		modelID:   "claude",
+		doStream: func(ctx context.Context, _ provider.CallOptions) (*provider.StreamResult, error) {
+			stream := make(chan provider.StreamPart)
+			go func() {
+				defer close(stream)
+				stream <- provider.StreamPart{
+					Type:         provider.PartError,
+					APICallError: provider.NewAPICallError(provider.APICallErrorOptions{Message: "provider error"}),
+				}
+				<-ctx.Done()
+			}()
+			return &provider.StreamResult{Stream: stream}, nil
+		},
+	}
+	wrapped := middleware.Wrap(middleware.WrapOptions{
+		Model: model,
+		Middleware: []middleware.Middleware{RecordingMiddleware(RecordingOptions{
+			ClientResolver: func(context.Context) *agento11y.Client { return env.Client },
+		})},
+	})
+	ctx, cancel := context.WithCancel(context.Background())
+	streamResult, err := wrapped.DoStream(ctx, provider.CallOptions{})
+	require.NoError(t, err)
+	_, ok := <-streamResult.Stream
+	require.True(t, ok)
+	cancel()
+	for range streamResult.Stream {
+	}
+	assert.Eventually(t, func() bool { return env.RequestCount() == 1 }, 2*time.Second, 10*time.Millisecond)
+	require.NoError(t, env.Client.Shutdown(context.Background()))
+
+	gen := env.SingleGenerationJSON(t)
+	callErr, _ := gen["call_error"].(string)
+	assert.Contains(t, callErr, "context canceled")
+	assert.NotContains(t, callErr, "provider error")
+}
+
+func TestRecordingMiddleware_StreamConsumerAbandons_RecordsCancellation(t *testing.T) {
+	env := testkit.NewEnv(t)
+	model := &mockLanguageModel{
+		provider_: "anthropic",
+		modelID:   "claude",
+		doStream: func(ctx context.Context, _ provider.CallOptions) (*provider.StreamResult, error) {
+			stream := make(chan provider.StreamPart)
+			go func() {
+				defer close(stream)
+				stream <- provider.StreamPart{Type: provider.PartTextDelta, ID: "text-1", Delta: "partial"}
+				<-ctx.Done()
+			}()
+			return &provider.StreamResult{Stream: stream}, nil
+		},
+	}
 	wrapped := middleware.Wrap(middleware.WrapOptions{
 		Model: model,
 		Middleware: []middleware.Middleware{RecordingMiddleware(RecordingOptions{
@@ -355,19 +408,28 @@ func TestRecordingMiddleware_StreamConsumerAbandons_DrainsAndRecords(t *testing.
 	require.True(t, ok)
 	cancel()
 
-	// Drain the rest of the tee channel. The recorder finalizes promptly after
-	// consumer disconnect while the provider stream drains in the background.
 	for range streamResult.Stream {
 	}
 
 	assert.Eventually(t, func() bool {
 		return env.RequestCount() >= 1
 	}, 2*time.Second, 10*time.Millisecond, "recording finalized even after consumer abandonment")
+	require.NoError(t, env.Client.Shutdown(context.Background()))
+	gen := env.SingleGenerationJSON(t)
+	callErr, _ := gen["call_error"].(string)
+	assert.Contains(t, callErr, "context canceled")
+	output, ok := gen["output"].([]any)
+	require.True(t, ok)
+	require.Len(t, output, 1)
+	message := output[0].(map[string]any)
+	parts := message["parts"].([]any)
+	require.Len(t, parts, 1)
+	assert.Equal(t, "partial", parts[0].(map[string]any)["text"])
 }
 
 func TestRecordingMiddleware_StreamCancellationFinalizesIdleProvider(t *testing.T) {
 	env := testkit.NewEnv(t)
-	upstream := make(chan provider.StreamPart)
+	upstream := make(chan provider.StreamPart, 1)
 	defer close(upstream)
 	model := &mockLanguageModel{
 		provider_: "anthropic",
@@ -396,7 +458,12 @@ func TestRecordingMiddleware_StreamCancellationFinalizesIdleProvider(t *testing.
 	assert.Eventually(t, func() bool {
 		return env.RequestCount() == 1
 	}, 2*time.Second, 10*time.Millisecond)
+	upstream <- provider.StreamPart{Type: provider.PartTextDelta, Delta: "late"}
+	assert.Never(t, func() bool { return len(upstream) == 0 }, 100*time.Millisecond, 10*time.Millisecond)
 	require.NoError(t, env.Client.Shutdown(context.Background()))
+	gen := env.SingleGenerationJSON(t)
+	callErr, _ := gen["call_error"].(string)
+	assert.Contains(t, callErr, "context canceled")
 }
 
 func TestRecordingMiddleware_NilContextProvider_LogsOnce(t *testing.T) {

--- a/middleware/agentobservability/testdata/stream/text_only/expected_generation.json
+++ b/middleware/agentobservability/testdata/stream/text_only/expected_generation.json
@@ -3,6 +3,7 @@
     "provider": "anthropic",
     "name": "claude-sonnet-4-5"
   },
+  "response_model": "claude-sonnet-4-5",
   "input": [
     {
       "role": "user",

--- a/middleware/agentobservability/testdata/stream/text_reasoning_signature/expected_generation.json
+++ b/middleware/agentobservability/testdata/stream/text_reasoning_signature/expected_generation.json
@@ -3,6 +3,7 @@
     "provider": "anthropic",
     "name": "claude-sonnet-4-5"
   },
+  "response_model": "claude-sonnet-4-5",
   "input": [
     {
       "role": "user",

--- a/middleware/agentobservability/testdata/stream/text_tool_call/expected_generation.json
+++ b/middleware/agentobservability/testdata/stream/text_tool_call/expected_generation.json
@@ -3,6 +3,7 @@
     "provider": "anthropic",
     "name": "claude-sonnet-4-5"
   },
+  "response_model": "claude-sonnet-4-5",
   "input": [
     {
       "role": "user",

--- a/openspec/specs/agent-observability-middleware/spec.md
+++ b/openspec/specs/agent-observability-middleware/spec.md
@@ -62,8 +62,9 @@ Context helpers:
 - `ParentGenerationIDsFromContext(ctx context.Context) []string`.
 - `WithLinkedGenerationID(ctx context.Context, id string) context.Context`.
 
-Sentinel error:
+Sentinel errors:
 - `ErrHookDenied error`.
+- `ErrHookTransformFailed error`.
 
 #### Scenario: HookDenialError unwraps to sentinel
 
@@ -127,7 +128,7 @@ If `opts.ClientResolver` is itself `nil`, the middleware SHALL behave as if ever
 
 `RecordingMiddleware` SHALL call `opts.ContextProvider(ctx)` once per request and use the returned `ContextInfo` to populate:
 - `agento11y.GenerationStart.UserID` (falls back to `agento11y.UserIDFromContext(ctx)` when `ContextInfo.UserID` is empty).
-- `agento11y.GenerationStart.Metadata` (merged on top of metadata derived from `ProviderOptions` and `params`).
+- `agento11y.GenerationStart.Metadata` (used as caller metadata; reserved derivations from `ProviderOptions`, `params`, and usage override conflicting keys in the final generation).
 - `agento11y.GenerationStart.Tags` (merged on top of any tags carried via context).
 - `agento11y.GenerationStart.AgentName` / `AgentVersion` (override `agento11y.AgentNameFromContext` / `agento11y.AgentVersionFromContext` when set).
 
@@ -153,10 +154,11 @@ If `opts.ContextProvider` is `nil`, the middleware SHALL log a warning at most o
 - `Input.Tools` is derived from `params.Tools`. Function tools map directly; provider-defined tools (e.g. Anthropic `web_search`, `code_execution`) MAY map with their type preserved so Agent Observability can annotate them.
 - `Input.MaxTokens`, `Temperature`, `TopP`, `ToolChoice` are derived from the corresponding `provider.CallOptions` fields.
 - Anthropic thinking-budget metadata (`agento11y.gen_ai.request.thinking.budget_tokens`) is derived from `params.ProviderOptions["anthropic"]` via `json.RawMessage` decoding, not by importing `providers/anthropic`.
-- `Output` is a single assistant `agento11y.Message` whose parts mirror supported `result.Content` entries (text, tool-call, reasoning, file, and reasoning-file parts). Empty reasoning parts SHALL be omitted.
+- `Output` contains an assistant `agento11y.Message` for supported model content and additional tool-role messages for tool-result entries. Empty reasoning parts SHALL be omitted.
 - `Usage` maps from `result.Usage` (input tokens, output tokens, cache hits where applicable).
 - `StopReason` is produced by `finishReasonToAgento11yStop(result.FinishReason)` and SHALL match the string values the legacy `internal/llm/claude/` path emitted (e.g. `"end_turn"`, `"max_tokens"`, `"tool_use"`, `"stop_sequence"`).
-- `Metadata` is a merge of `ctxInfo.Metadata` and `map_provider_options.go` derivations.
+- `Metadata` starts with caller metadata, then applies reserved request and usage derivations. Derived Anthropic thinking-budget and positive server-tool request counts SHALL override conflicting caller values, matching the pinned agento11y Anthropic helper.
+- Provider tool calls and results SHALL retain recoverable Anthropic discriminators, including MCP metadata and configured provider-tool aliases for web search, web fetch, code execution, and tool search. Irrecoverable provider subtypes MAY use the generic discriminator.
 - `Tags` is a merge of `ctxInfo.Tags` and any tags from context.
 
 #### Scenario: System message folds into SystemPrompt
@@ -177,6 +179,11 @@ If `opts.ContextProvider` is `nil`, the middleware SHALL log a warning at most o
 
 - **WHEN** `params.ProviderOptions["anthropic"]` carries a JSON object containing a `thinking` field with a positive `budget_tokens` value
 - **THEN** the resulting `Generation.Metadata["agento11y.gen_ai.request.thinking.budget_tokens"]` SHALL equal that integer
+
+#### Scenario: Anthropic server-tool usage is recorded
+
+- **WHEN** `result.Usage.Raw` contains positive `server_tool_use.web_search_requests` or `web_fetch_requests`
+- **THEN** generation metadata SHALL contain the corresponding Agent Observability usage keys and their sum as `total_requests`
 
 #### Scenario: Byte-equal output to agento11y anthropic helper
 
@@ -228,12 +235,13 @@ Hook preflight evaluation SHALL exclude `file` and `reasoning-file` media so rec
 `StreamRecorder` SHALL accumulate `agento11y.Generation.Output` from a sequence of `provider.StreamPart` values observed via `Observe`. It SHALL:
 - Append `PartTextDelta` payloads into the active assistant text part.
 - Append non-empty `PartReasoningDelta` payloads into the active assistant reasoning part. Signature-only reasoning blocks with no visible text SHALL NOT produce an Agent Observability thinking part.
-- Append `PartToolCallDelta` payloads into the active assistant tool-call part.
+- Append `PartToolInputDelta` payloads into the active assistant tool-call part.
 - Map supported `PartFile` and `PartReasoningFile` events to media parts.
-- Record the first observed payload-bearing part's timestamp via `FirstChunkAt()`; supported file events SHALL be payload-bearing.
+- Record the first semantic model-output timestamp via `FirstChunkAt()`. Non-empty text, reasoning, and tool-input deltas, tool calls, and supported file events SHALL be payload-bearing; finish, error, tool-result, metadata, and empty-delta events SHALL NOT establish time to first token.
+- Coalesce preliminary tool-result updates by exact tool-call ID and tool name and include only completed tool results in the final generation output. Distinct completed results SHALL remain distinct even when an ID is reused.
 - Capture `FinishReason` from `PartFinish` and observe `Usage` from every usage-bearing stream part using the shared streaming aggregation behavior.
 
-`Generation()` SHALL return an `agento11y.Generation` whose `Output` is a single assistant message constructed from the accumulated state. Assistant text, reasoning, tool-call, and media parts SHALL retain the order in which their first provider events were observed.
+`Generation()` SHALL return an `agento11y.Generation` whose `Output` contains an assistant message for accumulated model parts plus tool-role messages for completed tool results. Assistant text, reasoning, tool-call, and media parts SHALL retain the order in which their first provider events were observed.
 
 #### Scenario: Stream usage preserves strongest values
 
@@ -263,7 +271,7 @@ Hook preflight evaluation SHALL exclude `file` and `reasoning-file` media so rec
 
 #### Scenario: Tool-call deltas accumulate by tool-call ID
 
-- **GIVEN** a stream emits multiple `PartToolCallDelta` events for the same tool-call ID with incremental JSON argument fragments
+- **GIVEN** a stream emits multiple `PartToolInputDelta` events for the same tool-call ID with incremental JSON argument fragments
 - **WHEN** the recorder is observed
 - **THEN** the resulting tool-call part SHALL have the concatenated argument JSON
 
@@ -276,7 +284,7 @@ Hook preflight evaluation SHALL exclude `file` and `reasoning-file` media so rec
 
 ### Requirement: Recording uses response model identity when available
 
-Agent Observability recording SHALL use backend response metadata as the canonical generation model identity when a successful provider response supplies both provider and model ID. When response metadata omits either provider or model ID, recording SHALL preserve the model identity from `GenerationStart`.
+Agent Observability recording SHALL use backend response metadata as the canonical generation model identity when a successful provider response supplies both provider and model ID. When response metadata omits either provider or model ID, recording SHALL preserve the model identity from `GenerationStart`. Generate and stream `ResponseModel` SHALL default to the requested model and SHALL be overridden by a non-empty response model.
 
 #### Scenario: Generate response overrides transport model identity
 
@@ -339,20 +347,20 @@ When response metadata changes the canonical generation model identity from the 
 3. Call `client.StartGeneration` (for `WrapGenerate`) or `client.StartStreamingGeneration` (for `WrapStream`).
 4. Invoke the inner model.
 5. On success:
-   - For generate: call `recorder.SetResult(MapGenerateResult(params, result, ctxInfo))`.
+   - For generate: map the result with the original `GenerationStart` so requested-model fallback is available, then call `recorder.SetResult`.
    - For stream: tee the result stream channel, feed each part to a `StreamRecorder`, and at end-of-stream call `recorder.SetResult(streamRecorder.Generation())`.
 6. On an error returned before a stream opens: call `recorder.SetCallError(err)`. When a stream emits `PartError`, call `recorder.SetCallError(err)` and also call `recorder.SetResult` with the partial generation, including aggregated usage observed before or on the error part.
 
 `RecordingMiddleware` SHALL NOT modify `params` and SHALL NOT modify the result.
 
-For streams, the recording goroutine SHALL select on `ctx.Done()` to avoid blocking on consumer disconnect, and SHALL drain the upstream channel after consumer abandonment to avoid leaking the producer goroutine.
+For streams, the recording goroutine SHALL select on `ctx.Done()` to avoid blocking on consumer disconnect. Cancellation before observed upstream completion SHALL be recorded as the call error and SHALL take precedence over an earlier `PartError`. The middleware SHALL NOT start an unbounded detached drain when the provider ignores cancellation; provider stream producers are responsible for honoring the call context.
 
 #### Scenario: Generate path records on success
 
 - **GIVEN** a `RecordingMiddleware` with a non-nil `ClientResolver`
 - **WHEN** the inner model's `DoGenerate` returns a non-nil result and `nil` error
 - **THEN** the middleware SHALL call `StartGeneration` once
-- **AND** SHALL call `recorder.SetResult` once with `MapGenerateResult(params, result, ctxInfo)`
+- **AND** SHALL call `recorder.SetResult` once with the generation mapped from `params`, `result`, `ctxInfo`, and the original `GenerationStart`
 - **AND** SHALL NOT call `recorder.SetCallError`
 
 #### Scenario: Generate path records on error
@@ -377,11 +385,12 @@ For streams, the recording goroutine SHALL select on `ctx.Done()` to avoid block
 - **AND** the consumer SHALL receive exactly the same N parts in the same order
 - **AND** `recorder.SetResult` SHALL be called once after the upstream channel closes
 
-#### Scenario: Stream goroutine cleans up on consumer disconnect
+#### Scenario: Stream cancellation records an error and cleans up
 
-- **WHEN** the consumer abandons the result stream by cancelling its context before the upstream completes
+- **WHEN** the consumer cancels its context before the upstream completes
 - **THEN** the recording goroutine SHALL NOT block indefinitely
-- **AND** the upstream channel SHALL be drained so the producer can return
+- **AND** the generation SHALL record the context cancellation as its call error
+- **AND** the middleware SHALL NOT start a detached goroutine that waits indefinitely for the upstream channel to close
 
 ### Requirement: HooksMiddleware enforces preflight policy
 


### PR DESCRIPTION
## Summary

- Preserve partial stream telemetry while recording cancellation as an error, without detached provider drains.
- Correct streamed tool correlation, TTFT classification, response identity, usage metadata, and provider-specific output discriminators.

## Code Changes

- Give cancellation before observed completion precedence over earlier stream error parts while retaining already observed output.
- Track tool-call occurrences independently, coalesce preliminary results by exact ID/name, and require unambiguous result metadata inheritance.
- Establish TTFT only from semantic model output and accumulate response model/timestamp metadata across stream events.
- Make reserved transport and derived usage metadata authoritative, including Anthropic server-tool usage.
- Recover supported MCP, tool-search, web-search/fetch, code-execution, bash, and text-editor discriminators through exact provider IDs and aliases.

## Tests And Fixtures

- Added regressions for cancellation, partial output, reused tool IDs, preliminary results, TTFT, metadata precedence, response-model fallback, cumulative response metadata, and provider-tool subtypes.
- Updated Agent Observability conformance snapshots and OpenSpec requirements.

## Validation

- `cd middleware/agentobservability && go test ./...`
- `cd middleware/agentobservability && go test -race ./...`
- `cd middleware/agentobservability && go vet ./...`
- `mise run lint`
- `mise run test-short`
- `mise run parity-check`
- `openspec validate --all --strict`
- Stream cancellation/error lifecycle tests repeated 50 times
- `git diff --check`

## Residual Risk

- Agent Observability has no direct Vercel implementation; parity evidence comes from pinned agento11y/provider behavior and repository fixtures.
- Provider-specific subtypes already discarded at the provider-neutral boundary remain generic.

## Stack

- 3 of 3; based on #134.
- Review this PR as the diff against PR 2, not against `main`.
