### PR TITLE
feat(openai): support preconfigured Responses clients

### DIFF
--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -23,6 +23,24 @@ Continue with [Generate text from Go](../getting-started/backend-only.md) or
 [Full-stack chat](../getting-started/full-stack-chat.md). The same model also
 works with tools, structured output, middleware, and Agents.
 
+## Use a preconfigured client
+
+Use `NewResponsesWithClient` when authentication or transport must be configured
+on the underlying OpenAI client. For example, the OpenAI Go SDK's
+`github.com/openai/openai-go/v3/bedrock` client, imported as `openaibedrock`,
+uses the standard AWS credential chain and signs requests to the Bedrock Mantle
+Responses endpoint with SigV4:
+
+```go
+client, err := openaibedrock.NewClient(ctx, openaibedrock.Config{
+	AWSRegion: "us-east-1",
+})
+if err != nil {
+	return err
+}
+model := openai.NewResponsesWithClient(client, "gpt-5.6-luna")
+```
+
 ## Configure a call
 
 Set request-scoped headers with `aisdk.WithHeaders`. Headers configured through

--- a/openspec/changes/archive/2026-09-07-add-openai-responses-client-constructor/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-07-add-openai-responses-client-constructor/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-09-07

--- a/openspec/changes/archive/2026-09-07-add-openai-responses-client-constructor/design.md
+++ b/openspec/changes/archive/2026-09-07-add-openai-responses-client-constructor/design.md
@@ -1,0 +1,40 @@
+## Context
+
+The provider model stores an `openai-go` `responses.ResponseService`, but its only public constructor creates a standard API-key client internally. The official `openai-go/v3/bedrock` package returns a normal `openai.Client` whose Responses service carries endpoint resolution and SigV4 middleware.
+
+The registered upstream `@ai-sdk/openai@4.0.41` baseline supports provider-level transport configuration but has no Go client-injection equivalent. This change is an additive, parity-preserving Go adaptation and does not alter request conversion or wire output.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Allow callers to supply an official preconfigured OpenAI client.
+- Preserve all existing model options and API-key constructor behavior.
+- Verify that client-level Bedrock Mantle SigV4 configuration reaches Responses requests unchanged.
+
+**Non-Goals:**
+
+- Implement SigV4 signing in this provider.
+- Add Bedrock-specific configuration to the provider API.
+- Change request conversion, response mapping, or streaming behavior.
+
+## Decisions
+
+### Accept the official `openai.Client` value
+
+Expose `NewResponsesWithClient(client openai.Client, modelID string, opts ...Option)`. This matches the value returned by both `openai.NewClient` and `bedrock.NewClient`, keeps authentication ownership in the official SDK, and avoids duplicating security-sensitive signing middleware.
+
+Accepting only `responses.ResponseService` was considered but rejected because callers naturally construct the public top-level client, and the service value is primarily an implementation detail of that client. Adding provider-specific SigV4 options was rejected because this adapter should remain authentication-agnostic.
+
+### Share model initialization
+
+Both constructors use a private helper for model identity, ID generation, and functional options. The existing constructor continues to build its client exactly as before; the new constructor assigns the supplied client's Responses service.
+
+### Use focused transport coverage
+
+A unit test supplies deterministic fake AWS credentials and an in-memory HTTP transport to the official Bedrock client. It verifies endpoint selection and SigV4 credential scope without network access or real credentials. No conformance fixture changes are needed because request bodies and provider output remain unchanged.
+
+## Risks / Trade-offs
+
+- **Public API depends on the concrete `openai-go` client type** → This module already exposes and depends on that SDK for raw request options, and Go module version selection keeps consumers on one compatible version.
+- **Only generation is exercised by the new signing test** → Generation and streaming share the same stored Responses service and request-option path; existing tests cover both paths.

--- a/openspec/changes/archive/2026-09-07-add-openai-responses-client-constructor/proposal.md
+++ b/openspec/changes/archive/2026-09-07-add-openai-responses-client-constructor/proposal.md
@@ -1,0 +1,23 @@
+## Why
+
+The OpenAI Responses provider always constructs its own API-key client, which prevents callers from using provider-specific OpenAI clients that configure authentication at construction time. In particular, Amazon Bedrock Mantle requires the OpenAI Go SDK's Bedrock client to apply SigV4 signing to Responses requests.
+
+## What Changes
+
+- Add an additive constructor that accepts a preconfigured `openai-go` client.
+- Preserve the existing API-key constructor and all model behavior.
+- Document and test Amazon Bedrock Mantle SigV4 as the motivating client configuration.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `openai-responses-provider`: Extend provider construction to support preconfigured OpenAI clients while retaining the existing API-key constructor.
+
+## Impact
+
+The public API of `providers/openai` gains one constructor. Existing callers and wire behavior are unchanged. Consumers can configure alternate authentication, endpoint, middleware, retry, and transport behavior through `github.com/openai/openai-go/v3` before creating the language model.

--- a/openspec/changes/archive/2026-09-07-add-openai-responses-client-constructor/specs/openai-responses-provider/spec.md
+++ b/openspec/changes/archive/2026-09-07-add-openai-responses-client-constructor/specs/openai-responses-provider/spec.md
@@ -1,0 +1,30 @@
+## MODIFIED Requirements
+
+### Requirement: Provider construction and identity
+The system SHALL provide a `providers/openai` Go module exposing both
+`NewResponses(apiKey, modelID string, opts ...Option) provider.LanguageModel`
+and
+`NewResponsesWithClient(client openai.Client, modelID string, opts ...Option) provider.LanguageModel`.
+Each constructor SHALL return a value implementing `provider.LanguageModel`
+backed by the OpenAI Responses API via `github.com/openai/openai-go`. The model
+SHALL report `SpecificationVersion() == "v4"`, `Provider() == "openai"`, and
+`ModelID()` equal to the constructor `modelID`. The API-key constructor SHALL
+create a standard OpenAI client configured with the supplied key. The
+preconfigured-client constructor SHALL preserve the client's endpoint,
+authentication, middleware, retries, and transport. Both constructors SHALL
+accept functional options including `WithRequestOptions(...)` for model request
+options. Construction SHALL NOT panic or perform network calls.
+
+#### Scenario: Construct a Responses model
+- **WHEN** `NewResponses("test-key", "gpt-4o")` is called
+- **THEN** it returns a non-nil `provider.LanguageModel`
+- **AND** `Provider()` is `"openai"`, `ModelID()` is `"gpt-4o"`, and `SpecificationVersion()` is `"v4"`
+
+#### Scenario: Base URL override for testing
+- **WHEN** `NewResponses("test-key", "gpt-4o", WithRequestOptions(option.WithBaseURL(server.URL)))` is constructed
+- **THEN** subsequent `DoGenerate`/`DoStream` calls target the overridden base URL
+
+#### Scenario: Use a preconfigured Bedrock client
+- **WHEN** an OpenAI Go client is configured for the Bedrock Mantle Responses endpoint with AWS SigV4 credentials and passed to `NewResponsesWithClient`
+- **THEN** subsequent model calls use the configured Mantle endpoint
+- **AND** requests retain the client's SigV4 authentication scoped to the `bedrock-mantle` service

--- a/openspec/changes/archive/2026-09-07-add-openai-responses-client-constructor/tasks.md
+++ b/openspec/changes/archive/2026-09-07-add-openai-responses-client-constructor/tasks.md
@@ -1,0 +1,9 @@
+## 1. Provider API
+
+- [x] 1.1 Add the preconfigured-client Responses constructor while preserving the API-key constructor, and verify the OpenAI provider builds
+- [x] 1.2 Add focused coverage using the official Bedrock client, and verify the request targets Mantle with a `bedrock-mantle` SigV4 credential scope
+
+## 2. Documentation and Validation
+
+- [x] 2.1 Document the constructor and Bedrock Mantle usage in godoc and the OpenAI provider guide, and verify Markdown lint passes
+- [x] 2.2 Run OpenAI provider tests, vet, lint, formatting, and diff checks

--- a/openspec/specs/openai-responses-provider/spec.md
+++ b/openspec/specs/openai-responses-provider/spec.md
@@ -7,16 +7,21 @@ and conformance expectations needed to stay aligned with Vercel's upstream AI
 SDK behavior.
 
 ## Requirements
+
 ### Requirement: Provider construction and identity
-The system SHALL provide a `providers/openai` Go module exposing
+The system SHALL provide a `providers/openai` Go module exposing both
 `NewResponses(apiKey, modelID string, opts ...Option) provider.LanguageModel`
-that returns a value implementing `provider.LanguageModel` backed by the OpenAI
-Responses API via `github.com/openai/openai-go`. The model SHALL report
-`SpecificationVersion() == "v4"`, `Provider() == "openai"`, and `ModelID()` equal
-to the constructor `modelID`. The constructor SHALL accept functional options
-including `WithRequestOptions(...)` to set transport-level concerns such as the
-base URL and HTTP client for testing. Construction SHALL NOT panic and SHALL NOT
-perform network calls.
+and
+`NewResponsesWithClient(client openai.Client, modelID string, opts ...Option) provider.LanguageModel`.
+Each constructor SHALL return a value implementing `provider.LanguageModel`
+backed by the OpenAI Responses API via `github.com/openai/openai-go`. The model
+SHALL report `SpecificationVersion() == "v4"`, `Provider() == "openai"`, and
+`ModelID()` equal to the constructor `modelID`. The API-key constructor SHALL
+create a standard OpenAI client configured with the supplied key. The
+preconfigured-client constructor SHALL preserve the client's endpoint,
+authentication, middleware, retries, and transport. Both constructors SHALL
+accept functional options including `WithRequestOptions(...)` for model request
+options. Construction SHALL NOT panic or perform network calls.
 
 #### Scenario: Construct a Responses model
 - **WHEN** `NewResponses("test-key", "gpt-4o")` is called
@@ -26,6 +31,11 @@ perform network calls.
 #### Scenario: Base URL override for testing
 - **WHEN** `NewResponses("test-key", "gpt-4o", WithRequestOptions(option.WithBaseURL(server.URL)))` is constructed
 - **THEN** subsequent `DoGenerate`/`DoStream` calls target the overridden base URL
+
+#### Scenario: Use a preconfigured Bedrock client
+- **WHEN** an OpenAI Go client is configured for the Bedrock Mantle Responses endpoint with AWS SigV4 credentials and passed to `NewResponsesWithClient`
+- **THEN** subsequent model calls use the configured Mantle endpoint
+- **AND** requests retain the client's SigV4 authentication scoped to the `bedrock-mantle` service
 
 ### Requirement: System message conversion
 The provider SHALL convert system messages according to the resolved

--- a/providers/openai/doc.go
+++ b/providers/openai/doc.go
@@ -15,6 +15,9 @@
 //
 //	model := openai.NewResponses(apiKey, "gpt-4o")
 //
+// Use [NewResponsesWithClient] when the OpenAI client requires custom
+// authentication or transport configuration, such as Amazon Bedrock SigV4.
+//
 // Per-call OpenAI options are passed via
 // CallOptions.ProviderOptions["openai"] as an [OpenAIResponsesOptions] value.
 package openai

--- a/providers/openai/model.go
+++ b/providers/openai/model.go
@@ -29,6 +29,23 @@ type model struct {
 
 // NewResponses creates a [provider.LanguageModel] for the OpenAI Responses API.
 func NewResponses(apiKey, modelID string, opts ...Option) provider.LanguageModel {
+	m := newModel(modelID, opts...)
+	clientOpts := append([]option.RequestOption{option.WithAPIKey(apiKey)}, m.requestOpts...)
+	client := openaisdk.NewClient(clientOpts...)
+	m.client = client.Responses
+	return m
+}
+
+// NewResponsesWithClient creates a [provider.LanguageModel] using a
+// preconfigured OpenAI client. Use it when authentication or transport must be
+// configured at client construction, such as for Amazon Bedrock SigV4 signing.
+func NewResponsesWithClient(client openaisdk.Client, modelID string, opts ...Option) provider.LanguageModel {
+	m := newModel(modelID, opts...)
+	m.client = client.Responses
+	return m
+}
+
+func newModel(modelID string, opts ...Option) *model {
 	m := &model{
 		modelID:    modelID,
 		provider:   providerName,
@@ -37,9 +54,6 @@ func NewResponses(apiKey, modelID string, opts ...Option) provider.LanguageModel
 	for _, o := range opts {
 		o(m)
 	}
-	clientOpts := append([]option.RequestOption{option.WithAPIKey(apiKey)}, m.requestOpts...)
-	client := openaisdk.NewClient(clientOpts...)
-	m.client = client.Responses
 	return m
 }
 

--- a/providers/openai/model_constructor_test.go
+++ b/providers/openai/model_constructor_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/grafana/ai-sdk/provider"
+	"github.com/openai/openai-go/v3/bedrock"
 	"github.com/openai/openai-go/v3/option"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -125,6 +126,49 @@ func TestNewResponses_UsesProductionBaseURLByDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, res)
 	assert.Equal(t, "https://api.openai.com/v1/responses", capturedURL)
+}
+
+func TestNewResponsesWithClient_UsesPreconfiguredBedrockClient(t *testing.T) {
+	var capturedRequest *http.Request
+	httpClient := &http.Client{Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		capturedRequest = req.Clone(req.Context())
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body: io.NopCloser(strings.NewReader(`{
+				"id":"resp_123",
+				"created_at":1700000000,
+				"model":"gpt-5.6-luna",
+				"object":"response",
+				"status":"completed",
+				"output":[],
+				"usage":{"input_tokens":1,"output_tokens":1,"total_tokens":2}
+			}`)),
+			Request: req,
+		}, nil
+	})}
+	client, err := bedrock.NewClient(t.Context(), bedrock.Config{
+		AWSAccessKeyID:     "test-access-key",
+		AWSSecretAccessKey: "test-secret-key",
+		AWSSessionToken:    "test-session-token",
+		AWSRegion:          "us-east-1",
+		BaseURL:            "https://bedrock-mantle.us-east-1.api.aws/openai/v1",
+	}, option.WithHTTPClient(httpClient), option.WithMaxRetries(0))
+	require.NoError(t, err)
+
+	m := NewResponsesWithClient(client, "gpt-5.6-luna")
+	result, err := m.DoGenerate(t.Context(), provider.CallOptions{
+		Prompt: []provider.Message{provider.UserText("hi")},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	require.NotNil(t, capturedRequest)
+
+	assert.Equal(t, "https://bedrock-mantle.us-east-1.api.aws/openai/v1/responses", capturedRequest.URL.String())
+	assert.Regexp(t, `^AWS4-HMAC-SHA256 Credential=test-access-key/\d{8}/us-east-1/bedrock-mantle/aws4_request,`, capturedRequest.Header.Get("Authorization"))
+	assert.NotEmpty(t, capturedRequest.Header.Get("X-Amz-Content-Sha256"))
+	assert.NotEmpty(t, capturedRequest.Header.Get("X-Amz-Date"))
+	assert.Equal(t, "test-session-token", capturedRequest.Header.Get("X-Amz-Security-Token"))
 }
 
 func TestModel_PerCallHeaders(t *testing.T) {


### PR DESCRIPTION
## Summary

- add `NewResponsesWithClient` for OpenAI Responses models backed by a preconfigured `openai-go` client
- preserve the client's endpoint, authentication middleware, retries, and transport configuration
- document and test Bedrock Mantle SigV4 as the motivating use case

## Why

The existing constructor always creates an API-key client internally. That prevents consumers from using `openai-go/v3/bedrock.NewClient`, which configures the OpenAI Responses client with the Bedrock Mantle endpoint and AWS SigV4 signing.

This keeps SigV4 implementation and credential handling in the official OpenAI Go SDK instead of duplicating security-sensitive signing logic in this provider.

## Compatibility and parity

- additive public API; `NewResponses` is unchanged
- request conversion, response mapping, streaming, and wire output are unchanged
- Go-specific client-injection extension; the registered `@ai-sdk/openai@4.0.41` baseline has no equivalent concrete Go client API
- no conformance fixture regeneration is required

## Validation

- `cd providers/openai && mise exec go@1.26.6 -- go test ./...`
- `cd providers/openai && go vet ./...`
- `golangci-lint run --config ../../.golangci.yml ./...`
- `markdownlint-cli2 docs/providers/openai.md`
- `openspec validate --all --strict`
- `git diff --check`

## Follow-up

After this lands, `grafana-assistant-app` can construct the Bedrock client with its region and ambient AWS credentials, then switch `dev-us-east-0` from the Mantle bearer credential to SigV4.
